### PR TITLE
Support for equations in PEST_HP 14.22

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,97 +1,103 @@
 
+add_subdirectory(flibs)
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod_files)
+include_directories(${CMAKE_BINARY_DIR}/mod_files)
+
 if(TARGET__TSPROC_EXECUTABLE)
+    add_executable(tsproc
+  
+                   tsp_data_structures.F90
+  
+                   compute_hi.cpp
+                   tsp_command_processors.F90
+                   tsp_equation_parser.F90
+                   tsp_input.F90
+                   tsp_main.F90
+                   tsp_main_loop.F90
+                   tsp_output.F90
+                   tsp_time_series_processors.F90
+                   tsp_utilities.F90
+                   wsc_additions.F90
+  
+                   generated/version_control.F90
+  
+                   wdm_support/DTTM90.FOR
+                   wdm_support/TSBUFR.FOR
+                   wdm_support/UTCHAR.FOR
+                   wdm_support/UTCP90.FOR
+                   wdm_support/UTDATE.FOR
+                   wdm_support/UTNUMB.FOR
+                   wdm_support/UTWDMD.FOR
+                   wdm_support/UTWDMF.FOR
+                   wdm_support/UTWDT1.FOR
+                   wdm_support/WDATM1.FOR
+                   wdm_support/WDATM2.FOR
+                   wdm_support/WDATRB.FOR
+                   wdm_support/WDBTCH.FOR
+                   wdm_support/WDMESS.FOR
+                   wdm_support/WDMID.FOR
+                   wdm_support/WDOP.FOR
+                   wdm_support/WDTMS1.FOR
+                   wdm_support/WDTMS2.FOR)
 
-  add_executable(tsproc
-
-            tokenize.F90
-
-            compute_hi.cpp
-            tsp_command_processors.F90
-            tsp_data_structures.F90
-            tsp_equation_parser.F90
-            tsp_input.F90
-            tsp_main.F90
-            tsp_main_loop.F90
-            tsp_output.F90
-            tsp_time_series_processors.F90
-            tsp_utilities.F90
-            wsc_additions.F90
-
-            generated/version_control.F90
-
-            wdm_support/DTTM90.FOR
-            wdm_support/TSBUFR.FOR
-            wdm_support/UTCHAR.FOR
-            wdm_support/UTCP90.FOR
-            wdm_support/UTDATE.FOR
-            wdm_support/UTNUMB.FOR
-            wdm_support/UTWDMD.FOR
-            wdm_support/UTWDMF.FOR
-            wdm_support/UTWDT1.FOR
-            wdm_support/WDATM1.FOR
-            wdm_support/WDATM2.FOR
-            wdm_support/WDATRB.FOR
-            wdm_support/WDBTCH.FOR
-            wdm_support/WDMESS.FOR
-            wdm_support/WDMID.FOR
-            wdm_support/WDOP.FOR
-            wdm_support/WDTMS1.FOR
-            wdm_support/WDTMS2.FOR )
-
-   install(TARGETS tsproc
-           RUNTIME
-           DESTINATION bin
-           )
+    target_link_libraries(tsproc
+        
+                          flibs_strings)
 
     set_target_properties(tsproc
-           PROPERTIES LINKER_LANGUAGE CXX)
+                          PROPERTIES LINKER_LANGUAGE CXX)
 
+    install(TARGETS tsproc
+            RUNTIME
+            DESTINATION bin)
 endif()
 
 if(TARGET__TSPROC_LIBRARY)
+    add_library(tsproclib STATIC
 
-  add_library(tsproclib STATIC
-            tokenize.F90
+                tsp_data_structures.F90
 
-            compute_hi.cpp
-            tsp_command_processors.F90
-            tsp_data_structures.F90
-            tsp_equation_parser.F90
-            tsp_input.F90
-            tsp_main.F90
-            tsp_main_loop.F90
-            tsp_output.F90
-            tsp_time_series_processors.F90
-            tsp_utilities.F90
-            wsc_additions.F90
+                compute_hi.cpp
+                tsp_command_processors.F90
+                tsp_equation_parser.F90
+                tsp_input.F90
+                tsp_main.F90
+                tsp_main_loop.F90
+                tsp_output.F90
+                tsp_time_series_processors.F90
+                tsp_utilities.F90
+                wsc_additions.F90
+  
+                generated/version_control.F90
+  
+                wdm_support/DTTM90.FOR
+                wdm_support/TSBUFR.FOR
+                wdm_support/UTCHAR.FOR
+                wdm_support/UTCP90.FOR
+                wdm_support/UTDATE.FOR
+                wdm_support/UTNUMB.FOR
+                wdm_support/UTWDMD.FOR
+                wdm_support/UTWDMF.FOR
+                wdm_support/UTWDT1.FOR
+                wdm_support/WDATM1.FOR
+                wdm_support/WDATM2.FOR
+                wdm_support/WDATRB.FOR
+                wdm_support/WDBTCH.FOR
+                wdm_support/WDMESS.FOR
+                wdm_support/WDMID.FOR
+                wdm_support/WDOP.FOR
+                wdm_support/WDTMS1.FOR
+                wdm_support/WDTMS2.FOR)
 
-            generated/version_control.F90
+    target_link_libraries(tsproclib
+        
+                          flibs_strings)
 
-            wdm_support/DTTM90.FOR
-            wdm_support/TSBUFR.FOR
-            wdm_support/UTCHAR.FOR
-            wdm_support/UTCP90.FOR
-            wdm_support/UTDATE.FOR
-            wdm_support/UTNUMB.FOR
-            wdm_support/UTWDMD.FOR
-            wdm_support/UTWDMF.FOR
-            wdm_support/UTWDT1.FOR
-            wdm_support/WDATM1.FOR
-            wdm_support/WDATM2.FOR
-            wdm_support/WDATRB.FOR
-            wdm_support/WDBTCH.FOR
-            wdm_support/WDMESS.FOR
-            wdm_support/WDMID.FOR
-            wdm_support/WDOP.FOR
-            wdm_support/WDTMS1.FOR
-            wdm_support/WDTMS2.FOR )
+    set_target_properties(tsproclib
+                          PROPERTIES LINKER_LANGUAGE CXX)
 
-   install( TARGETS tsproclib
+    install(TARGETS tsproclib
             ARCHIVE
-            DESTINATION lib )
-
-   set_target_properties( tsproclib
-            PROPERTIES LINKER_LANGUAGE CXX)
-
+            DESTINATION lib)
 endif()
-

--- a/src/flibs/CMakeLists.txt
+++ b/src/flibs/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+add_subdirectory(src)
+

--- a/src/flibs/src/CMakeLists.txt
+++ b/src/flibs/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+
+add_subdirectory(datastructures)
+add_subdirectory(strings)
+

--- a/src/flibs/src/datastructures/qsortarray_template.F90
+++ b/src/flibs/src/datastructures/qsortarray_template.F90
@@ -1,0 +1,117 @@
+!
+! qsortarray_template.f90 --
+!     QuickSort for arrays:
+!
+!     This template has to be preprocessed by defining the
+!     two following macros :
+!     - "_QSORTARRAY_TYPE" is the name of the derived type
+!     - "_QSORTARRAY_MODULE" is the module defining the
+!       derived type
+!
+!     Note:
+!     The data that need to be sorted are stored in
+!     an array. A comparison function is used to enable
+!     sorting wrt different criteria.
+!     The data have the generic type _QSORTARRAY_TYPE.
+!
+!     Note:
+!     Algorithm translated from Kernighan and Pike,
+!     The Practice of Programming.
+!
+!     $Id$
+!
+! Routines and functions specific to dictionaries
+!
+! qsort_array --
+!     Use the QuickSort algorithm to sort an array
+! Arguments:
+!     array      Array to be sorted
+!     compare    Comparison function
+!
+subroutine qsort_array( array, compare )
+  type ( _QSORTARRAY_TYPE ) , dimension(:) :: array
+  interface
+     integer function compare(f,g)
+       use _QSORTARRAY_MODULE , only : _QSORTARRAY_TYPE
+       type( _QSORTARRAY_TYPE ), intent(in) :: f, g
+     end function compare
+  end interface
+  type ( _QSORTARRAY_TYPE ) , dimension(:), allocatable :: backup
+  integer, dimension(:), allocatable         :: order
+  integer                                    :: i
+  allocate( backup(1:size(array) ) )
+  allocate( order(1:size(array) ) )
+  do i = 1,size(order)
+     order(i) = i
+  enddo
+  call qsort_sort( array, order, 1, size(array), compare )
+  do i = 1,size(order)
+     backup(i) = array(order(i))
+  enddo
+  array = backup
+  deallocate( backup )
+  deallocate( order  )
+end subroutine qsort_array
+! qsort_sort --
+!     Sort the array according to the QuickSort algorithm
+! Arguments:
+!     array      Array of data
+!     order      Array holding the order
+!     left       Start index
+!     right      End index
+!     compare    Comparison function
+!
+recursive subroutine qsort_sort( array, order, left, right, compare )
+  type ( _QSORTARRAY_TYPE ) , dimension(:) :: array
+  integer, dimension(:)         :: order
+  integer                       :: left
+  integer                       :: right
+  interface
+     integer function compare ( f , g )
+       use _QSORTARRAY_MODULE, only : _QSORTARRAY_TYPE
+       type(_QSORTARRAY_TYPE), intent(in) :: f, g
+     end function compare
+  end interface
+  integer                                    :: i
+  integer                                    :: last
+  if ( left .ge. right ) return
+  call qsort_swap( order, left, qsort_rand(left,right) )
+  last = left
+  do i = left+1, right
+     if ( compare(array(order(i)), array(order(left)) ) .lt. 0 ) then
+        last = last + 1
+        call qsort_swap( order, last, i )
+     endif
+  enddo
+  call qsort_swap( order, left, last )
+  call qsort_sort( array, order, left, last-1, compare )
+  call qsort_sort( array, order, last+1, right, compare )
+end subroutine qsort_sort
+! qsort_swap --
+!     Swap two array elements
+! Arguments:
+!     order      Array holding the order
+!     first      First index
+!     second     Second index
+!
+subroutine qsort_swap( order, first, second )
+  integer, dimension(:)         :: order
+  integer                       :: first, second
+  integer                       :: tmp
+  tmp           = order(first)
+  order(first)  = order(second)
+  order(second) = tmp
+end subroutine
+! qsort_rand --
+!     Determine a random integer number
+! Arguments:
+!     lower      Lowest value
+!     upper      Greatest value
+!
+integer function qsort_rand( lower, upper )
+  integer                       :: lower, upper
+  real                          :: r
+  call random_number( r )
+  qsort_rand =  lower + nint(r * (upper-lower))
+end function qsort_rand
+

--- a/src/flibs/src/strings/CMakeLists.txt
+++ b/src/flibs/src/strings/CMakeLists.txt
@@ -1,0 +1,16 @@
+
+set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod_files)
+include_directories(${CMAKE_BINARY_DIR}/mod_files)
+
+add_definitions(-D_VSTRING_ALLOCATABLE
+                -D_VSTRINGLIST_ALLOCATABLE)
+
+include_directories(../datastructures)
+
+add_library(flibs_strings
+
+            m_vstring.F90
+            m_vstringlist.F90
+            tokenize.F90
+            tokenlist.F90)
+

--- a/src/flibs/src/strings/m_vstring.F90
+++ b/src/flibs/src/strings/m_vstring.F90
@@ -1,0 +1,3460 @@
+!
+! m_vstring --
+!   This module provides OO services to manage strings of dynamic length.
+!   The goal of the current component is to provide higher-level
+!   services that the standard fortran currently provides.
+!   The component provides methods which mimic the services
+!   available in the Tcl language.
+!   It provides string comparison, string search and string
+!   matching methods.
+!   See in test_m_vstring to see a complete example of the
+!   services provided.
+!
+!   Overview
+!   A vstring is an array of characters.
+!   The simplest way to create a vstring is with vstring_new
+!   from a "character(len=<something>)" string.
+!   The length of the vstring is computed dynamically,
+!   depending on the current number of characters, with vstring_length.
+!   In the following example, the length is 9.
+!
+!     use m_vstring, only : &
+!       vstring_new, &
+!       vstring_free, &
+!       t_vstring, &
+!       vstring_length
+!     type ( t_vstring,) :: string1
+!     integer :: length
+!     call vstring_new ( string1 , "my string" )
+!     length = vstring_length (string1)
+!     call vstring_free( string1 )
+!
+!   Creating a string
+!   With vstring_new, one can also create a new vstring as a copy
+!   of an existing vstring.
+!   With vstring_new, one can also create a new vstring with an
+!   array of characters or with a repeated copy of an existing vstring.
+!   Destroy the vstring with vstring_free.
+!
+!   Concatenate two strings
+!   Two vstrings can be concatenated in two ways.
+!   The vstring_concat method returns a new vstring computed by the
+!   concatenation of the two strings.
+!   The vstring_append allows to add the characters of the 2nd vstring
+!   at the end of the current string.
+!   In the following example, the string3 is "my string is very interesting".
+!
+!     call vstring_new ( string1 , "my string" )
+!     call vstring_new ( string2 , " is very interesting" )
+!     string3 = vstring_concat ( string1 , string2 )
+!
+!   Modify the case
+!   The user can modify the case of a vstring.
+!   The vstring_tolower creates a new vstring with lower case characters.
+!   The vstring_toupper creates a new vstring with upper case characters.
+!   The vstring_totitle creates a new vstring with the first letter in
+!   upper case and all the other characters to lower case.
+!
+!   The user can know if two vstrings are equal with vstring_equals.
+!   Two vstrings can be compared with vstring_compare, which
+!   is based on the lexicographic order.
+!
+!   One can transform one vstring into a new one using a map with
+!   vstring_map.
+!
+!   Pattern matching
+!   The vstring_match method provides string-matching services in the glob-style.
+!   It manages "*" pattern (which matches 0 or more characters),
+!   the "?" pattern (which matches exactly one character),
+!   escape sequences and character ranges.
+!   The following example show how to compare a file name against a pattern :
+!
+!     call vstring_new ( string1 , "m_vstring.f90" )
+!     call vstring_new ( pattern , 'm_*.f90' )
+!     match = vstring_match ( string1 , pattern )
+!
+!   Validating a string
+!   The vstring_is method provides a way of validating data by
+!   computing whether the vstring is in a class of data, for example
+!   integer, real, digit, alphanumeric, etc...
+!   In the following example, the user can check whether the
+!   string read on standard input is an integer :
+!
+!     read ( 5 , * ) charstring
+!     call vstring_new ( string1 , charstring )
+!     isinteger = call vstring_is ( string1 , "integer" )
+!     if ( .NOT. isinteger ) then
+!       ! Generate an error
+!     endif
+!
+!   If the character set under use is not in one the pre-defined classes
+!   of vstring_is, the user can directly call vstring_isincharset or
+!   vstring_isinasciirange, which are the basic blocks of vstring_is.
+!
+!   Second string argument may be character string
+!   The design choice has been made to design the subroutines/functions
+!   so that their dummy arguments are generally only of type t_vstring.
+!   Another choice would have been to allways take as dummy arguments both
+!   t_vstring and "character (len=*)" strings, with module procedure
+!   interfaces to make them generic.
+!   The last choice ease the work of the client of the current component,
+!   which can use directly standard fortran constant strings (for example,
+!
+!     equals = vstring_equals ( string1 , "toto" )
+!
+!   instead of
+!
+!     type ( t_vstring ) :: string2
+!     call vstring_new ( string2 , "toto" )
+!     equals = vstring_equals ( string1 , string2 )
+!     call vstring_free ( string2 )
+!
+!   that is to say 5 lines instead of 1.
+!
+!   The main drawback is that the number of interfaces is at least
+!   multiplied by 2, if not 4 or 8 when the number of string arguments is more
+!   than 2. This makes the unit tests multiplied by the same number, if one
+!   want to exercise all the possible interfaces. That way was chosen
+!   by the original iso_varying_string module and lead to a heavy component,
+!   with a large number of lines and a small number of features, because
+!   all the time was lost in the management of such an heavy module.
+!   The other drawback is that is breaks the object oriented design
+!   so that the "type bound" procedure of F2003 cannot be used.
+!   The current choice is to focus mainly on the services provided,
+!   not the ease of use. That allows to provide much more features than
+!   in the original component, but complicates a little more the
+!   use in the client code.
+!   The choice done here is that the first argument is allways of type
+!   vstring (and called "this"), while the second argument (if any), mays
+!   by either of type vstring or of type "character (len=*).
+!   That solution allows to keep both consistency and ease of use at
+!   the maximum possible level.
+!   Several methods are designed this way, for example, vstring_equals,
+!   vstring_compare, vstring_append, vstring_concat and others.
+!
+!   Allocatable or pointer
+!   Two implementation of m_vstring are provided, depending on the compiler used :
+!   - the allocatable array of characters with the pre-processing macro _VSTRING_ALLOCATABLE,
+!   - the pointer array of characters with the pre-processing macro _VSTRING_POINTER
+!   If none of the macros are defined, the default implementation is _VSTRING_ALLOCATABLE.
+!   The two implementations provide exactly the same services.
+!   But the "allocatable" implementation allows to manage the vstring
+!   which are going out of the current scope so that the use of vstring_free
+!   is not necessary and memory leaks do not occur.
+!   Instead, with the pointer implementation, the call to vstring_free is
+!   strictly necessary (if not, memory is lost each time a new vstring is
+!   created).
+!   The current version of m_vstring has been tested with the
+!   following compilers and versions !
+!   - Intel Visual Fortran 8 : tested with _VSTRING_ALLOCATABLE and _VSTRING_POINTER
+!       But the allocatable version allows to debug more easily.
+!   - gfortran 2007/04/16 : tested with _VSTRING_POINTER (works fine,
+!       except for vstring_match)
+!   - g95 May  3 2007 : tested with _VSTRING_POINTER, OK
+!
+!   Dynamic or static buffer
+!   The internal algorithms provided by m_vstrings are based on
+!   basic fortran character strings. In several situations, the
+!   dynamic vstring has to be converted into a basic fortran character
+!   buffer string, which size has to be given explicitely in the source
+!   code, with the len = <something> statement (in the
+!   character ( len = <something>) ). Two solutions are provided,
+!   and the user can define the pre-processing macro
+!   _VSTRING_STATIC_BUFFER to configure that :
+!   - the first solution is to set the size of the buffer statically,
+!     to a constant integer value VSTRING_BUFFER_SIZE.
+!   - the second solution is to compute the size
+!     of the buffer dynamicaly, with the fortran 90 len = vstring_length(this)
+!     statement,
+!   If the _VSTRING_STATIC_BUFFER is defined, then character strings of
+!   constant size are used as buffers.
+!   If the _VSTRING_STATIC_BUFFER is not defined (which is the default),
+!   then character strings of dynamic size are used as buffers.
+!   The second solution is more efficient, because the strings are not
+!   oversized or undersized, depending on the real number of characters
+!   in the dynamic string. But the feature may not be provided
+!   by the compiler at hand. For example, problems with the dynamic
+!   length character string have been experienced with Intel Fortran 8.
+!
+!   Design
+!   This component has been designed with OO principles in mind.
+!   This is why the first argument of every method is named "this",
+!   which is the current object.
+!   If another string is required as a second argument, it may be either
+!   of type dynamic or as a character(len=*) type, to improve
+!   usability.
+!   This component is meant to evolve following the fortran 2003 standard
+!   and OO type-bound procedures.
+!
+!   Limitations
+!     - No regular expression algorithm is provided.
+!       But vstring_match allows to do string matching in glob-style.
+!     - The vstring_match does not work with gfortran 2007/04/16 because
+!       of a limitation in gfortran for zero-size arrays
+!     - the vstring_adjustl, vstring_adjustr, vstring_scan,
+!       vstring_adjustl, vstring_adjustr, vstring_is methods does not
+!       work with IVF8 because strings declared like this :
+!         character (len = vstring_length(this) :: character
+!       are not consistent strings, probably because of a bug
+!       in the implementation of len = pure function value in IVF8.
+!     - Fortran does not allow to manage character encodings such as UTF8.
+!
+!   Preprocessing
+!   The following preprocessing macro must be considered :
+!   _VSTRING_STATIC_BUFFER : see  the section "Dynamic or static buffer"
+!   _VSTRING_ALLOCATABLE or _VSTRING_POINTER : see the section "Allocatable or pointer"
+!
+!   History
+!   This module was originally based on the iso_varying_string.f90 module
+!   by Rich Townsend.
+!
+!   TODO
+!   - Refactor the component and use datastructures/vectors.f90
+!
+! ******************************************************************************
+! *                                                                            *
+! * iso_varying_string.f90                                                     *
+! *                                                                            *
+! * Copyright (c) 2003, Rich Townsend <rhdt@bartol.udel.edu>                   *
+! * All rights reserved.                                                       *
+! *                                                                            *
+! * Redistribution and use in source and binary forms, with or without         *
+! * modification, are permitted provided that the following conditions are     *
+! * met:                                                                       *
+! *                                                                            *
+! *  * Redistributions of source code must retain the above copyright notice,  *
+! *    this list of conditions and the following disclaimer.                   *
+! *  * Redistributions in binary form must reproduce the above copyright       *
+! *    notice, this list of conditions and the following disclaimer in the     *
+! *    documentation and/or other materials provided with the distribution.    *
+! *                                                                            *
+! * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS    *
+! * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,  *
+! * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR     *
+! * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR           *
+! * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,      *
+! * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,        *
+! * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR         *
+! * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF     *
+! * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING       *
+! * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS         *
+! * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.               *
+! *                                                                            *
+! ******************************************************************************
+!
+! Copyright (c) 2008 Michael Baudin michael.baudin@gmail.com
+! Copyright (c) 2008 Arjen Markus arjenmarkus@sourceforge.net
+!
+! $Id$
+!
+! Thanks    : Lawrie Schonfelder (bugfixes and design pointers), Walt Brainerd
+!             (conversion to F).
+! Note  : The current module does NOT conform to the API
+!         specified in ISO/IEC 1539-2:2000 (varying-length strings for
+!         Fortran 95).
+!
+module m_vstring
+  implicit none
+  private
+  !
+  ! t_vstring --
+  !   A vstring is implemented as an array of characters.
+  !   The length of the string is not stored. Instead,
+  !   it is computed by vstring_length each time it is
+  !   necessary with the intrinsic "size". It the length
+  !   was stored explicitely, it should be managed, which
+  !   could lead to bugs.
+  !
+  ! Choose your dynamic string system between _VSTRING_ALLOCATABLE , _VSTRING_POINTER
+  ! Allocatable arrays should be used by default.
+  ! But for compatibility of older fortran 90 compilers, pointers are also available.
+  ! These are the recommended settings :
+  ! _VSTRING_POINTER : gfortran, g95
+  ! _VSTRING_ALLOCATABLE : Intel Fortran 8.0
+  !
+  type, public :: t_vstring
+     private
+#ifdef _VSTRING_ALLOCATABLE
+     character(LEN=1), dimension(:), allocatable :: chars
+#endif
+#ifdef _VSTRING_POINTER
+     character(LEN=1), dimension(:), pointer :: chars => NULL()
+#endif
+  end type t_vstring
+  !
+  ! Public methods
+  !
+  public :: vstring_achar
+  public :: vstring_adjustl
+  public :: vstring_adjustr
+  public :: vstring_exists
+  public :: vstring_append
+  public :: vstring_char
+  public :: vstring_charindex
+  public :: vstring_compare
+  public :: vstring_concat
+  public :: vstring_equals
+  public :: vstring_first
+  public :: vstring_free
+  public :: vstring_iachar
+  public :: vstring_ichar
+  public :: vstring_index
+  public :: vstring_last
+  public :: vstring_length
+  public :: vstring_map
+  public :: vstring_match
+  public :: vstring_new
+  public :: vstring_random
+  public :: vstring_range
+  public :: vstring_reference_get
+  public :: vstring_replace
+  public :: vstring_reverse
+  public :: vstring_scan
+  public :: vstring_tolower
+  public :: vstring_totitle
+  public :: vstring_toupper
+  public :: vstring_trim
+  public :: vstring_trimleft
+  public :: vstring_trimright
+  public :: vstring_verify
+  public :: vstring_is
+  public :: vstring_isincharset
+  public :: vstring_isinasciirange
+  public :: vstring_set_stoponerror
+  public :: vstring_cast
+  !
+  ! vstring_new --
+  !   Generic constructor
+  !
+  interface vstring_new
+     module procedure vstring_new_empty
+     module procedure vstring_new_from_charstring
+     module procedure vstring_new_from_vstring
+     module procedure vstring_new_from_chararray
+     module procedure vstring_new_from_integer
+  end interface vstring_new
+  !
+  ! vstring_cast --
+  !   Generic converter from a vstring to a basic fortran data type
+  !
+  interface vstring_cast
+     module procedure vstring_cast_charstringfixed
+     module procedure vstring_cast_charstringauto
+     module procedure vstring_cast_tointeger
+     module procedure vstring_cast_toreal
+     module procedure vstring_cast_todp
+  end interface vstring_cast
+  !
+  ! vstring_equals --
+  !   Generic comparison between two strings
+  !
+  interface vstring_equals
+     module procedure vstring_equals_vstring
+     module procedure vstring_equals_charstring
+  end interface vstring_equals
+  !
+  ! vstring_compare --
+  !   Generic comparison between two strings.
+  !
+  interface vstring_compare
+     module procedure vstring_compare_vstring
+     module procedure vstring_compare_charstring
+  end interface vstring_compare
+  !
+  ! vstring_append --
+  !   Generic append to a vstring.
+  !
+  interface vstring_append
+     module procedure vstring_append_vstring
+     module procedure vstring_append_charstring
+  end interface vstring_append
+  !
+  ! vstring_concat --
+  !   Generic concatenate to a vstring.
+  !
+  interface vstring_concat
+     module procedure vstring_concat_vstring
+     module procedure vstring_concat_charstring
+  end interface vstring_concat
+  !
+  ! vstring_match --
+  !   Generic string matching.
+  !
+  interface vstring_match
+     module procedure vstring_match_vstring
+     module procedure vstring_match_charstring
+  end interface vstring_match
+  !
+  ! vstring_trim --
+  !   Generic string trim.
+  !
+  interface vstring_trim
+     module procedure vstring_trim_vstring
+     module procedure vstring_trim_charstring
+  end interface vstring_trim
+  !
+  ! vstring_trimleft --
+  !   Generic string trim.
+  !
+  interface vstring_trimleft
+     module procedure vstring_trimleft_vstring
+     module procedure vstring_trimleft_charstring
+  end interface vstring_trimleft
+  !
+  ! vstring_trimright --
+  !   Generic string trim.
+  !
+  interface vstring_trimright
+     module procedure vstring_trimright_vstring
+     module procedure vstring_trimright_charstring
+  end interface vstring_trimright
+  !
+  ! vstring_first --
+  !   Generic string search first.
+  !
+  interface vstring_first
+     module procedure vstring_first_vstring
+     module procedure vstring_first_charstring
+  end interface vstring_first
+  !
+  ! vstring_last --
+  !   Generic string search last.
+  !
+  interface vstring_last
+     module procedure vstring_last_vstring
+     module procedure vstring_last_charstring
+  end interface vstring_last
+  !
+  ! Constants
+  !
+  integer, parameter, public :: VSTRING_COMPARE_LOWER = -1
+  integer, parameter, public :: VSTRING_COMPARE_EQUAL = 0
+  integer, parameter, public :: VSTRING_COMPARE_GREATER = 1
+  integer, parameter, public :: VSTRING_INDEX_UNKNOWN = 0
+  character(len=*), parameter, public :: VSTRING_DIGITS = "0123456789"
+  character(len=*), parameter, public :: VSTRING_UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+  character(len=*), parameter, public :: VSTRING_LOWER = "abcdefghijklmnopqrstuvwxyz"
+  character(len=*), parameter, public :: VSTRING_CHARACTERSET = VSTRING_LOWER//VSTRING_DIGITS
+  character(len=*), parameter, public :: VSTRING_SPACE           = achar(32)
+  ! Ascii char #10 -> corresponds to \n : line_feed
+  character(len=*), parameter, public :: VSTRING_NEWLINE         = achar(10)
+  ! Ascii char #13 -> corresponds to \r : carriage return
+  character(len=*), parameter, public :: VSTRING_CARRIAGE_RETURN = achar(13)
+  ! Ascii char #9 -> corresponds to \t : tab
+  character(len=*), parameter, public :: VSTRING_TAB             = achar(9)
+  ! Ascii char #34 -> corresponds to "
+  character(len=*), parameter, public :: VSTRING_DOUBLEQUOTE             = achar(34)
+  ! Ascii char #39 -> corresponds to '
+  character(len=*), parameter, public :: VSTRING_SINGLEQUOTE             = achar(39)
+  character(len=*), parameter, public :: VSTRING_WHITESPACE = VSTRING_SPACE//VSTRING_NEWLINE//VSTRING_CARRIAGE_RETURN//VSTRING_TAB
+  character(len=*), parameter, public :: VSTRING_HEXDIGITS = "abcdefABCDEF"//VSTRING_DIGITS
+  character(len=*), parameter, public :: VSTRING_PUNCTUATION = "_,;:.?![](){}@"//VSTRING_DOUBLEQUOTE//VSTRING_SINGLEQUOTE
+  !
+  ! Maximum number of characters in the buffer.
+  !
+  integer , parameter :: VSTRING_BUFFER_SIZE = 1000
+  !
+  ! Static parameters
+  !
+  logical, save :: random_process_initialize = .false.
+  !
+  ! Total number of currently available (allocated) strings.
+  ! Note :
+  ! This is mainly for debugging purposes of the vstring module itself or client algorithms.
+  ! It allows to check the consistency of vstring_new/vstring_free statements.
+  integer, save :: vstring_number_of_strings = 0
+  !
+  ! Set to true to stop whenever an error comes in the vstring component.
+  logical, save :: vstring_stoponerror = .true.
+  !
+  ! TODO : Flags for error management.
+  !
+  integer, parameter :: VSTRING_ERROR_OK = 0
+  integer, parameter :: VSTRING_ERROR_WRONGINDEX = 1
+  integer, parameter :: VSTRING_ERROR_STRINGNOTCREATED = 2
+contains
+  !
+  ! vstring_new_empty --
+  !   Constructor based on an empty string.
+  !   The created vstring has length 0 and no character.
+  !
+  subroutine vstring_new_empty ( this )
+    type ( t_vstring ) , intent(inout) :: this
+    call vstring_new_from_charstring ( this , "" )
+  end subroutine vstring_new_empty
+  !
+  ! vstring_new_from_charstring --
+  !   Constructor based on a character(len=*).
+  ! Arguments
+  !   char_string : the new vstring is filled with the
+  !     characters found in char_string.
+  !
+  subroutine vstring_new_from_charstring ( this , char_string )
+    type ( t_vstring ) , intent(inout) :: this
+    character(LEN=*), intent(in)    :: char_string
+    character ( len = 200) :: message
+    integer :: length
+    integer :: icharacter
+    logical :: isallocated
+    integer :: this_length
+    !
+    ! Check that the data is empty
+    !
+    isallocated = vstring_exists ( this )
+    if ( isallocated ) then
+       this_length = vstring_length(this)
+       write ( message , * ) "Object is allready associated with size ", this_length
+       call vstring_error ( this , message , "vstring_new_from_charstring" )
+    endif
+    length = LEN ( char_string )
+    allocate ( this % chars(length))
+    do icharacter = 1, length
+       this % chars(icharacter) = char_string (icharacter:icharacter)
+    enddo
+    !
+    ! Update the counter of strings
+    !
+    call vstring_reference_add ()
+  end subroutine vstring_new_from_charstring
+  !
+  ! vstring_new_from_vstring --
+  !   Constructor based on a vstring ( simple copy ).
+  !
+  subroutine vstring_new_from_vstring ( this , vstring )
+    type ( t_vstring ) , intent(inout) :: this
+    type ( t_vstring ) , intent(in) :: vstring
+    integer :: length
+    character ( len = 200) :: message
+    integer :: icharacter
+    integer :: this_length
+    integer :: status
+    call vstring_check_string ( vstring , "vstring_new_from_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    !
+    ! Check that the data is empty
+    !
+    if ( vstring_exists ( this ) ) then
+       this_length = vstring_length(this)
+       write ( message , * ) "Object is allready associated with size ", this_length , &
+            " in vstring_new_from_charstring"
+       call vstring_error ( this , message )
+    endif
+    length = vstring_length ( vstring )
+    allocate ( this % chars ( length ) )
+    do icharacter = 1 , length
+       this % chars(icharacter) = vstring % chars (icharacter)
+    enddo
+    !
+    ! Update the counter of strings
+    !
+    call vstring_reference_add ()
+  end subroutine vstring_new_from_vstring
+  !
+  ! vstring_new_from_chararray --
+  !   Constructor based on an array of characters
+  !
+  subroutine vstring_new_from_chararray ( this , chararray )
+    type ( t_vstring ) , intent(inout) :: this
+    character(len=1), dimension(:), intent(in) :: chararray
+    integer :: length
+    character ( len = 300 ) :: message
+    integer :: icharacter
+    integer :: this_length
+    !
+    ! Check that the data is empty
+    !
+    if ( vstring_exists ( this ) ) then
+       this_length = vstring_length(this)
+       write ( message , * ) "Object is allready associated with size ", this_length , &
+            " in vstring_new_from_chararray"
+       call vstring_error ( this , message )
+    endif
+    length = size ( chararray )
+    allocate ( this % chars ( length ) )
+    do icharacter = 1, length
+       this % chars(icharacter) = chararray (icharacter)(1:1)
+    enddo
+    !
+    ! Update the counter of strings
+    !
+    call vstring_reference_add ()
+  end subroutine vstring_new_from_chararray
+  !
+  ! vstring_new_from_integer --
+  !   Repeat the string ncount times and concatenate the result to create the new string.
+  !   If not given, the default string is the blank space.
+  ! Note :
+  !   This can be considered as an implementation of "vstring_repeat".
+  !
+  subroutine vstring_new_from_integer ( this , ncount , string )
+    type ( t_vstring ) , intent(inout) :: this
+    integer, intent(in) :: ncount
+    type ( t_vstring ) , intent(in), optional :: string
+    integer :: length
+    character ( len = 300 ) :: message
+    type(t_vstring) :: string_real
+    integer :: icount
+    integer :: string_length
+    integer :: first
+    integer :: last
+    integer :: this_length
+    !
+    ! Check that the data is empty
+    !
+    if ( vstring_exists ( this ) ) then
+       this_length = vstring_length(this)
+       write ( message , * ) "Object is allready associated with size ", this_length , &
+            " in vstring_new_from_chararray"
+       call vstring_error ( this , message )
+    endif
+    !
+    ! Check the value of the integer
+    !
+    if ( ncount < 0 ) then
+       write ( message , * ) "The given number of counts ", ncount , " is inconsistent ", &
+            " in vstring_new_from_chararray"
+       call vstring_error ( this , message )
+    endif
+    !
+    ! Process options
+    !
+    if (present ( string ) ) then
+       call vstring_new ( string_real , string )
+    else
+       call vstring_new ( string_real , VSTRING_SPACE )
+    endif
+    !
+    ! Create the object
+    !
+    string_length = vstring_length ( string_real )
+    length = ncount * string_length
+    allocate ( this % chars ( length ) )
+    do icount = 1, ncount
+       first = string_length * ( icount - 1 ) + 1
+       last = string_length * icount
+       this % chars( first : last ) = string_real % chars ( 1 : string_length )
+    enddo
+    !
+    ! Cleanup
+    !
+    call vstring_free ( string_real )
+    !
+    ! Update the counter of strings
+    !
+    call vstring_reference_add ()
+  end subroutine vstring_new_from_integer
+  !
+  ! vstring_free --
+  !   Destructor.
+  ! NOTE :
+  !   The use of the destructor is OPTIONAL.
+  !   See the thread " New ISO_VARYING_STRING implementation
+  !   (without memory leaks)" on comp.lang.fortran :
+  !   "On most systems, memory is memory :-).  However, there is a
+  !   difference between how ALLOCATABLE variables and POINTER
+  !   variables are handled.  ALLOCATABLE variables are always
+  !   deallocated automatically when thay go out of scope (unless
+  !   they have the SAVE attribute).  POINTER variables usually
+  !   are not.  The reason is that the program may have associated
+  !   additional pointers, that aren't going out of scope, with the
+  !   same target as the one that is."
+  !
+  subroutine vstring_free ( this )
+    type ( t_vstring ) , intent(inout) :: this
+    logical :: string_allocated
+    character ( len = 300 ) :: message
+    integer :: status
+    string_allocated = vstring_exists ( this )
+    if ( string_allocated ) then
+       deallocate ( this % chars , stat=status )
+       if ( status /= 0 ) then
+          write ( message , * ) "There was an error while deallocating the string."
+          call vstring_error ( this , message , "vstring_free" )
+       endif
+#ifdef _VSTRING_POINTER
+       nullify ( this % chars )
+#endif
+       !
+       ! Update the counter of strings
+       !
+       call vstring_reference_remove ()
+    else
+       write ( message , * ) "The current varying string is not allocated ", &
+            " in vstring_free"
+       call vstring_error ( this , message , "vstring_free" )
+    endif
+  end subroutine vstring_free
+  !
+  ! vstring_reference_add --
+  !   Static method.
+  !   Increase the counter of currently referenced strings.
+  !
+  subroutine vstring_reference_add ( )
+    implicit none
+    vstring_number_of_strings = vstring_number_of_strings + 1
+  end subroutine vstring_reference_add
+  !
+  ! vstring_reference_remove --
+  !   Static method.
+  !   Decrease the counter of currently referenced strings.
+  !
+  subroutine vstring_reference_remove ( )
+    implicit none
+    vstring_number_of_strings = vstring_number_of_strings - 1
+  end subroutine vstring_reference_remove
+  !
+  ! vstring_reference_get --
+  !   Static method.
+  !   Returns the number of currently referenced strings.
+  !
+  integer function vstring_reference_get ( )
+    implicit none
+    vstring_reference_get = vstring_number_of_strings
+  end function vstring_reference_get
+  !
+  ! vstring_exists --
+  !   Returns .true. if the string is allocated.
+  !
+  pure function vstring_exists ( this ) result ( exists )
+    type ( t_vstring ) , intent(in) :: this
+    logical :: exists
+#ifdef _VSTRING_ALLOCATABLE
+    exists = allocated ( this%chars )
+#endif
+#ifdef _VSTRING_POINTER
+    exists = associated ( this%chars)
+#endif
+  end function vstring_exists
+  !
+  ! vstring_equals_vstring --
+  !   Perform a character-by-character comparison of strings this and string2.
+  !   Returns true if this and string2 are identical, or .false when not.
+  !   If nocase is set to true, the case of the characters is not taken into account.
+  !   The default behaviour is to take into account for case of characters.
+  !   If length is specified, then only the first length characters are used in the comparison.
+  !
+  function vstring_equals_vstring ( this , string2 , nocase , length ) result (equals)
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: string2
+    logical , intent (in), optional :: nocase
+    integer , intent ( in ), optional :: length
+    logical :: equals
+    logical :: nocase_real
+    integer :: length1
+    integer :: length2
+    integer :: icharacter
+    type(t_vstring) :: char1
+    type(t_vstring) :: char2
+    type(t_vstring) :: char1_case
+    type(t_vstring) :: char2_case
+    integer :: length_real
+    integer :: length_min
+    integer :: last
+    character ( len = 300 ) :: message
+    integer :: status
+    call vstring_check_string ( this , "vstring_equals" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2 , "vstring_equals" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    !
+    ! Process options
+    !
+    equals = .false.
+
+    if ( present ( nocase ) ) then
+       nocase_real = nocase
+    else
+       nocase_real = .false.
+    endif
+    !
+    ! If the length parameter is here, it must be consistent with both strings lengths
+    !
+    length1 = vstring_length ( this )
+    length2 = vstring_length ( string2 )
+    length_min = min ( length1 , length2 )
+    if ( present ( length ) ) then
+       if ( length > length_min ) then
+          write ( message , * ) "The given number of characters to compare ", length ,&
+               " does not match the number of characters present in both strings : ", length_min, &
+               " in vstring_equals."
+          call vstring_error ( this , message )
+       endif
+       length_real = length
+    else
+       length_real = vstring_length ( this )
+    endif
+    !
+    ! Compare lengths, if the length optional parameter is not here.
+    !
+    equals = .true.
+    if ( .NOT. present ( length ) ) then
+       if (length1/=length2) then
+          equals = .false.
+       endif
+    endif
+    !
+    ! Compare characters.
+    !
+    if ( equals ) then
+       last = min ( length_real , length_min )
+       do icharacter = 1 , last
+          !
+          ! Compute the character at index #icharacter, with modified case if necessary.
+          !
+          char1 = vstring_index ( this , icharacter )
+          char2 = vstring_index ( string2 , icharacter )
+          if ( nocase_real ) then
+             char1_case = vstring_tolower ( char1 )
+             char2_case = vstring_tolower ( char2 )
+          else
+             call vstring_new ( char1_case , char1 )
+             call vstring_new ( char2_case , char2 )
+          endif
+          !
+          ! Make the comparison
+          !
+          if ( char1_case % chars ( 1 )/=char2_case % chars ( 1 ) ) then
+             equals = .false.
+          endif
+          call vstring_free ( char1 )
+          call vstring_free ( char2 )
+          call vstring_free ( char1_case )
+          call vstring_free ( char2_case )
+          if (.NOT.equals) then
+             exit
+          endif
+       enddo
+    endif
+  end function vstring_equals_vstring
+  !
+  ! vstring_equals_charstring --
+  !   Interface to vstring_equals_vstring to manage character string.
+  !
+  function vstring_equals_charstring ( this , string2 , nocase , length ) result (equals)
+    type ( t_vstring ) , intent(in) :: this
+    character(len=*), intent(in) :: string2
+    logical , intent ( in ), optional :: nocase
+    integer , intent ( in ), optional :: length
+    logical                          :: equals
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    equals = vstring_equals_vstring ( this , vstring2 , nocase , length )
+    call vstring_free ( vstring2 )
+  end function vstring_equals_charstring
+  !
+  ! vstring_cast_charstringfixed --
+  !   Convert a varying string into a character string
+  !   (fixed length)
+  !   If the number of characters in the target charstring
+  !   is not large enough, the target charstring is truncated, that is,
+  !   contains only the first characters of the current dynamic string.
+  !
+  subroutine vstring_cast_charstringfixed ( this , length , char_string )
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(in)              :: length
+    character ( LEN = length ) , intent(out) :: char_string
+    integer :: length_this
+    integer :: icharacter
+    length_this = vstring_length ( this )
+    do icharacter = 1, min ( length_this , length )
+       char_string ( icharacter : icharacter ) = this % chars ( icharacter )
+    end do
+    !
+    ! Pad with white spaces
+    !
+    do icharacter = length_this + 1 , length
+       char_string ( icharacter : icharacter ) = VSTRING_SPACE
+    end do
+  end subroutine vstring_cast_charstringfixed
+  !
+  ! vstring_cast_charstringauto --
+  !   Convert a varying string into a character string
+  !   (automatic length)
+  !   If the number of characters in the target charstring
+  !   is not large enough, the target charstring is truncated, that is,
+  !   contains only the first characters of the current dynamic string.
+  !
+  subroutine vstring_cast_charstringauto ( this , char_string )
+    type ( t_vstring ) , intent(in) :: this
+    character ( LEN = * ) , intent(out) :: char_string
+    integer :: length_this
+    integer :: icharacter
+    integer :: charlength
+    !
+    ! Compute lengths
+    !
+    length_this = vstring_length ( this )
+    charlength = len ( char_string )
+    !
+    ! Fill with characters
+    !
+    do icharacter = 1, min ( length_this , charlength )
+       char_string ( icharacter : icharacter ) = this % chars ( icharacter )
+    end do
+    !
+    ! Pad with white spaces
+    !
+    do icharacter = length_this + 1 , charlength
+       char_string ( icharacter : icharacter ) = VSTRING_SPACE
+    end do
+  end subroutine vstring_cast_charstringauto
+  !
+  ! vstring_cast_tointeger --
+  !   Returns the integer stored in the current string.
+  !
+  subroutine vstring_cast_tointeger ( this , value )
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: value
+    character ( len = 200 ) :: message
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: char_string
+#else
+    character ( len = vstring_length ( this ) ) :: char_string
+#endif
+    logical :: hastype
+    hastype = vstring_is ( this , "integer" )
+    if ( .NOT. hastype ) then
+       write ( message , * ) "Current string is not an integer in vstring_cast_tointeger"
+       call vstring_error ( this , message )
+    else
+       call vstring_cast ( this , char_string )
+       read ( char_string , * , err = 100 , end = 100) value
+    endif
+    return
+100 continue
+    !
+    ! An error was generated while reading in buffer.
+    !
+    write ( message , * ) "The string could not be converted to integer in vstring_cast_tointeger"
+    call vstring_error ( this , message )
+  end subroutine vstring_cast_tointeger
+  !
+  ! vstring_cast_toreal --
+  !   Returns the real stored in the current string.
+  !
+  subroutine vstring_cast_toreal ( this , value )
+    type ( t_vstring ) , intent(in) :: this
+    real, intent(out) :: value
+    character ( len = 200 ) :: message
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: char_string
+#else
+    character ( len = vstring_length ( this ) ) :: char_string
+#endif
+    logical :: hastype
+    hastype = vstring_is ( this , "real" )
+    if ( .NOT. hastype ) then
+       write ( message , * ) "Current string is not a real in vstring_cast_toreal"
+       call vstring_error ( this , message )
+    else
+       call vstring_cast ( this , char_string )
+       read ( char_string , * , err = 100 , end = 100) value
+    endif
+    return
+100 continue
+    !
+    ! An error was generated while reading in buffer.
+    !
+    write ( message , * ) "The string could not be converted to real in vstring_cast_toreal"
+    call vstring_error ( this , message )
+  end subroutine vstring_cast_toreal
+  !
+  ! vstring_cast_todp --
+  !   Returns the double precision stored in the current string.
+  !
+  subroutine vstring_cast_todp ( this , value )
+    type ( t_vstring ) , intent(in) :: this
+    double precision, intent(out) :: value
+    character ( len = 500 ) :: message
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: char_string
+#else
+    character ( len = vstring_length ( this ) ) :: char_string
+#endif
+    logical :: hastype
+    hastype = vstring_is ( this , "real" )
+    if ( .NOT. hastype ) then
+       write ( message , * ) "Current string is not a real in vstring_cast_toreal"
+       call vstring_error ( this , message )
+    else
+       call vstring_cast ( this , char_string )
+       read ( char_string , * , err = 100 , end = 100) value
+    endif
+    return
+100 continue
+    !
+    ! An error was generated while reading in buffer.
+    !
+    write ( message , * ) "The string could not be converted to real in vstring_cast_toreal"
+    call vstring_error ( this , message )
+  end subroutine vstring_cast_todp
+  !
+  ! vstring_length --
+  !   Returns the length of the current dynamic string.
+  !
+  pure function vstring_length ( this ) result ( length )
+    type ( t_vstring ) , intent(in) :: this
+    integer                          :: length
+    logical :: string_allocated
+    string_allocated = vstring_exists ( this )
+    if ( string_allocated ) then
+       length = SIZE(this%chars)
+    else
+       length = 0
+       ! One cannot use the error management system provided by vstring_error
+       ! because it is convenient that vstring_length is pure,
+       ! to set the dimension of automatic-length character strings.
+       !write ( message , * ) "Object is not created in vstring_length"
+       !call vstring_error ( this , message )
+    endif
+  end function vstring_length
+  !
+  ! vstring_concat_vstring --
+  !   Returns a new string made by the concatenation of two dynamic strings.
+  !
+  function vstring_concat_vstring ( this , string2 ) result ( concat_string )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: string2
+    type(t_vstring)             :: concat_string
+    integer                          :: len_string_a
+    integer :: concat_length
+    integer :: status
+    call vstring_check_string ( this , "vstring_concat" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2 , "vstring_concat" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    len_string_a = vstring_length(this)
+    concat_length = len_string_a+vstring_length(string2)
+    call vstring_new ( concat_string , concat_length )
+    concat_string % chars(:len_string_a) = this%chars
+    concat_string % chars(len_string_a+1:) = string2%chars
+  end function vstring_concat_vstring
+  !
+  ! vstring_concat_charstring --
+  !   Interface to vstring_concat_vstring to manage character strings
+  !
+  function vstring_concat_charstring ( this , string2 ) result (concat_string)
+    type ( t_vstring ) , intent(in) :: this
+    character(len=*), intent(in) :: string2
+    type(t_vstring)             :: concat_string
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    concat_string = vstring_concat_vstring ( this , vstring2 )
+    call vstring_free ( vstring2 )
+  end function vstring_concat_charstring
+  !
+  ! vstring_compare_vstring --
+  !   Perform a character-by-character comparison of strings this and string2.
+  !   Returns -1, 0, or 1, depending on whether this is lexicographically less
+  !   than, equal to, or greater than string2.
+  !   If nocase is set to true, the case of the characters is not taken into account.
+  !   The default behaviour is to take into account for case of characters.
+  !   If length is specified, then only the first length characters are used in the comparison.
+  !
+  !   A value of 999 means that either string was not properly initialized.
+  !
+  function vstring_compare_vstring ( this , string2 , nocase , length ) result ( compare )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: string2
+    logical , intent (in), optional :: nocase
+    integer , intent ( in ), optional :: length
+    integer                     :: compare
+    integer :: common_length
+    integer :: length_this , length2
+    integer :: icharacter
+    logical :: comparison_done
+    logical :: nocase_real
+    type(t_vstring) :: char1
+    type(t_vstring) :: char2
+    type(t_vstring) :: char1_case
+    type(t_vstring) :: char2_case
+    character (len=300) :: message
+    integer :: status
+    !
+    ! Process options
+    !
+    compare = 999
+
+    if ( present ( nocase ) ) then
+       nocase_real = nocase
+    else
+       nocase_real = .false.
+    endif
+    call vstring_check_string ( this , "vstring_compare" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2 , "vstring_compare" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    !
+    ! Initialize
+    !
+    length_this = vstring_length ( this )
+    length2 = vstring_length ( string2 )
+    common_length = min ( length_this , length2 )
+    comparison_done = .false.
+    !
+    ! If the length optional parameter is given, reduce the number of characters which are compared.
+    !
+    if ( present ( length ) ) then
+       if ( length > common_length ) then
+          write ( message , * ) "The given number of characters to compare ", length ,&
+               " does not match the number of characters present in both strings : ", common_length , &
+               " in vstring_equals."
+          call vstring_error ( this , message )
+       endif
+       common_length = length
+    endif    !
+    ! Compare character by character until there is one difference
+    !
+    do icharacter = 1 , common_length
+       !
+       ! Compute the character at index #icharacter, with modified case if necessary.
+       !
+       char1 = vstring_index ( this , icharacter )
+       char2 = vstring_index ( string2 , icharacter )
+       if ( nocase_real ) then
+          char1_case = vstring_tolower ( char1 )
+          char2_case = vstring_tolower ( char2 )
+       else
+          call vstring_new ( char1_case , char1 )
+          call vstring_new ( char2_case , char2 )
+       endif
+       !
+       ! Make the comparison of the modified characters
+       !
+       if ( char1_case % chars ( 1 ) < char2_case % chars ( 1 ) ) then
+          comparison_done = .true.
+          compare = VSTRING_COMPARE_LOWER
+       elseif ( char1_case % chars ( 1 ) > char2_case % chars ( 1 ) ) then
+          comparison_done = .true.
+          compare = VSTRING_COMPARE_GREATER
+       endif
+       call vstring_free ( char1 )
+       call vstring_free ( char2 )
+       call vstring_free ( char1_case )
+       call vstring_free ( char2_case )
+       !
+       ! Note : the "exit" is done afterwards, in order to let the system free the characters.
+       !
+       if ( comparison_done ) then
+          exit
+       endif
+    enddo
+    !
+    ! If the common part is the same, compare the lengths
+    !
+    if ( .NOT. comparison_done ) then
+       if ( present ( length ) ) then
+          ! If the length argument is provided, then the previous algorithm has
+          ! proved that all characters from 1 to length are equal.
+          compare = VSTRING_COMPARE_EQUAL
+       else
+          if ( length_this == length2 ) then
+             compare = VSTRING_COMPARE_EQUAL
+          elseif ( length_this > length2 ) then
+             compare = VSTRING_COMPARE_GREATER
+          else
+             compare = VSTRING_COMPARE_LOWER
+          endif
+       endif
+    endif
+  end function vstring_compare_vstring
+  !
+  ! vstring_compare_charstring --
+  !   Interface to vstring_compare_vstring to manage character string.
+  !
+  function vstring_compare_charstring ( this , string2 , nocase , length ) result ( compare )
+    type ( t_vstring ) , intent(in) :: this
+    character (len=*), intent(in) :: string2
+    logical , intent ( in ), optional :: nocase
+    integer , intent ( in ), optional :: length
+    integer                     :: compare
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    compare = vstring_compare_vstring ( this , vstring2 , nocase , length )
+    call vstring_free ( vstring2 )
+  end function vstring_compare_charstring
+  !
+  ! vstring_trim_vstring --
+  !   Returns a new string except that any leading or trailing characters
+  !   from the set given by chars are removed.
+  !   If chars is not specified then white space is removed (spaces, tabs,
+  !   newlines, and carriage returns).
+  !
+  function vstring_trim_vstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in), optional :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring)             :: chars_real
+    type(t_vstring) :: trimmedLeft
+    integer :: status
+    call vstring_check_string ( this , "vstring_trim_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if (present ( chars )) then
+       call vstring_check_string ( chars , "vstring_trim_vstring" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       call vstring_new ( chars_real , chars )
+    else
+       call vstring_new ( chars_real , VSTRING_WHITESPACE )
+    endif
+    !
+    ! 1. Trim left
+    !
+    trimmedLeft = vstring_trimleft ( this , chars_real )
+    !
+    ! 2. Trim right
+    !
+    trim_string = vstring_trimright ( trimmedLeft , chars_real )
+    !
+    ! 3. Cleanup
+    !
+    call vstring_free ( chars_real )
+    call vstring_free ( trimmedLeft )
+  end function vstring_trim_vstring
+  !
+  ! vstring_trim_charstring --
+  !   Interface to vstring_trim_vstring to manage character strings.
+  !
+  function vstring_trim_charstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    character (len=*), intent(in) :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring) :: vchars
+    call vstring_new ( vchars , chars )
+    trim_string = vstring_trim_vstring ( this , vchars )
+    call vstring_free ( vchars )
+  end function vstring_trim_charstring
+  !
+  ! vstring_trimleft_vstring --
+  !   Returns a new string except that any leading characters
+  !   from the set given by chars are removed.
+  !   If chars is not specified then white space is removed
+  !   (spaces, tabs, newlines, and carriage returns).
+  !
+  function vstring_trimleft_vstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in), optional :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring)             :: chars_real
+    integer :: length
+    integer :: icharacter
+    integer :: searched_index
+    type(t_vstring) :: current_char
+    integer :: first
+    logical :: first_found
+    integer :: status
+    call vstring_check_string ( this , "vstring_trimleft_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if (present ( chars )) then
+       call vstring_check_string ( chars , "vstring_trimleft_vstring" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       call vstring_new ( chars_real , chars )
+    else
+       call vstring_new ( chars_real , VSTRING_WHITESPACE )
+    endif
+    length = vstring_length ( this )
+    !
+    ! 1. Compute the first character index which is not in the set of characters to remove
+    !
+    first_found = .false.
+    do icharacter = 1 , length
+       current_char = vstring_index ( this , icharacter )
+       searched_index = vstring_first ( chars_real , current_char )
+       call vstring_free ( current_char )
+       if ( searched_index == VSTRING_INDEX_UNKNOWN ) then
+          first = icharacter
+          first_found = .true.
+          exit
+       endif
+    enddo
+    !
+    ! 2. If there are characters not to remove, the result is the string range from first to length.
+    ! If all the characters of the current string are to remove, create an empty string.
+    !
+    if ( first_found ) then
+       trim_string = vstring_range ( this , first , length )
+    else
+       call vstring_new ( trim_string , "" )
+    endif
+    !
+    ! 3. Cleanup
+    !
+    call vstring_free ( chars_real )
+  end function vstring_trimleft_vstring
+  !
+  ! vstring_trimleft_charstring --
+  !   Interface to vstring_trimleft_vstring to manage character strings.
+  !
+  function vstring_trimleft_charstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    character (len=*), intent(in) :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring) :: vchars
+    call vstring_new ( vchars , chars )
+    trim_string = vstring_trimleft_vstring ( this , vchars )
+    call vstring_free ( vchars )
+  end function vstring_trimleft_charstring
+  !
+  ! vstring_trimright --
+  !   Returns a value equal to string except that any trailing characters from the set given by chars are removed.
+  !   If chars is not specified then white space is removed (spaces, tabs, newlines, and carriage returns).
+  !
+  function vstring_trimright_vstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in), optional :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring)             :: chars_real
+    integer :: length
+    integer :: icharacter
+    integer :: searched_index
+    type(t_vstring) :: current_char
+    integer :: last
+    logical :: last_found
+    integer :: status
+    call vstring_check_string ( this , "vstring_trimright_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if (present ( chars )) then
+       call vstring_check_string ( chars , "vstring_trimright_vstring" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       call vstring_new ( chars_real , chars )
+    else
+       call vstring_new ( chars_real , VSTRING_WHITESPACE )
+    endif
+    length = vstring_length ( this )
+    !
+    ! 1. Compute the last character index which is not in the set of characters to remove
+    !
+    last_found = .false.
+    do icharacter = length , 1 , -1
+       current_char = vstring_index ( this , icharacter )
+       searched_index = vstring_last ( chars_real , current_char )
+       call vstring_free ( current_char )
+       if ( searched_index == VSTRING_INDEX_UNKNOWN ) then
+          last = icharacter
+          last_found = .true.
+          exit
+       endif
+    enddo
+    !
+    ! 2. If there are characters not to remove, the result is the string range from 1 to last.
+    ! If all the characters of the current string are to remove, create an empty string.
+    !
+    if ( last_found ) then
+       trim_string = vstring_range ( this , 1 , last )
+    else
+       call vstring_new ( trim_string , "" )
+    endif
+    !
+    ! 3. Cleanup
+    !
+    call vstring_free ( chars_real )
+  end function vstring_trimright_vstring
+  !
+  ! vstring_trimright_charstring --
+  !   Interface to vstring_trimright_vstring to manage character strings.
+  !
+  function vstring_trimright_charstring ( this , chars ) result ( trim_string )
+    type ( t_vstring ) , intent(in) :: this
+    character (len=*), intent(in) :: chars
+    type(t_vstring)             :: trim_string
+    type(t_vstring) :: vchars
+    call vstring_new ( vchars , chars )
+    trim_string = vstring_trimright_vstring ( this , vchars )
+    call vstring_free ( vchars )
+  end function vstring_trimright_charstring
+  !
+  ! vstring_first_vstring --
+  !   Search in the current string for a sequence of characters that exactly match the characters in string2.
+  !   If found, return the index of the first character in the first such match within the current string.
+  !   If not found, return 0.
+  !   If first is specified, then the search is constrained to start with the character
+  !   in the current string specified by the index.
+  !
+  function vstring_first_vstring ( this , string2 , first ) result ( foundIndex )
+    type ( t_vstring ) , intent(in)   :: this
+    type ( t_vstring ) , intent(in)   :: string2
+    integer, intent(in), optional :: first
+    integer                       :: foundIndex
+    integer :: startIndex
+    integer :: icharacter
+    integer :: length
+    integer :: length_searched
+    integer :: rangeEndIndex
+    type(t_vstring)   :: substring
+    logical :: equals
+    integer :: status
+
+    foundIndex = 0
+
+    call vstring_check_string ( this , "vstring_first_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2 , "vstring_first_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if (present( first )) then
+       call vstring_check_index ( this , first )
+       startIndex = first
+    else
+       startIndex = 1
+    endif
+    length = vstring_length ( this )
+    length_searched = vstring_length ( string2 )
+    foundIndex = VSTRING_INDEX_UNKNOWN
+    !
+    ! The length of the string to search for is 0, which never matches.
+    !
+    if ( length_searched /= 0 ) then
+       do icharacter = startIndex , length
+          rangeEndIndex = icharacter + length_searched - 1
+          ! The number of characters to search for is greater than the number
+          ! of characters which are left to compare.
+          if ( rangeEndIndex > length ) then
+             exit
+          endif
+          substring = vstring_range ( this , icharacter , rangeEndIndex )
+          equals = vstring_equals ( substring , string2 )
+          call vstring_free ( substring )
+          if ( equals ) then
+             foundIndex = icharacter
+             exit
+          endif
+       enddo
+    endif
+  end function vstring_first_vstring
+  !
+  ! vstring_first_charstring --
+  !   Interface to vstring_first_vstring to manage character strings
+  !
+  function vstring_first_charstring ( this , string2 , first ) result ( foundIndex )
+    type ( t_vstring ) , intent(in)   :: this
+    character(len=*), intent(in)   :: string2
+    integer, intent(in), optional :: first
+    integer                       :: foundIndex
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    foundIndex = vstring_first_vstring ( this , vstring2 , first )
+    call vstring_free ( vstring2 )
+  end function vstring_first_charstring
+  !
+  ! vstring_last_vstring --
+  !   Search in the current string for a sequence of characters that exactly match the characters in string2.
+  !   If found, return the index of the last character in the first such match within the current string.
+  !   If not found, return 0.
+  !   If last is specified, then the search is constrained to start with the character in the current
+  !   string specified by the index.
+  !
+  function vstring_last_vstring ( this , string2 , last ) result ( foundIndex )
+    type ( t_vstring ) , intent(in)   :: this
+    type ( t_vstring ) , intent(in)   :: string2
+    integer, intent(in), optional     :: last
+    integer                           :: foundIndex
+    integer :: endIndex
+    integer :: icharacter
+    integer :: length
+    integer :: length_searched
+    integer :: rangeEndIndex
+    type(t_vstring)   :: substring
+    logical :: equals
+    integer :: status
+
+    foundIndex = 0
+
+    call vstring_check_string ( this , "vstring_last_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2  , "vstring_last_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    length = vstring_length ( this )
+    if (present( last )) then
+       call vstring_check_index ( this , last )
+       endIndex = last
+    else
+       endIndex = length
+    endif
+    length_searched = vstring_length ( string2 )
+    foundIndex = VSTRING_INDEX_UNKNOWN
+    !
+    ! The length of the string to search for is 0, which never matches.
+    !
+    if ( length_searched /= 0 ) then
+       do icharacter = endIndex , 1 , -1
+          rangeEndIndex = icharacter + length_searched - 1
+          ! The number of characters to search for is greater than the number
+          ! of characters which are left to compare.
+          if ( rangeEndIndex > length ) then
+             exit
+          endif
+          substring = vstring_range ( this , icharacter , rangeEndIndex )
+          equals = vstring_equals ( substring , string2 )
+          call vstring_free ( substring )
+          if ( equals ) then
+             foundIndex = icharacter
+             exit
+          endif
+       enddo
+    endif
+  end function vstring_last_vstring
+  !
+  ! vstring_last_charstring --
+  !   Interface to vstring_last_vstring to manage character strings
+  !
+  function vstring_last_charstring ( this , string2 , first ) result ( foundIndex )
+    type ( t_vstring ) , intent(in)   :: this
+    character(len=*), intent(in)   :: string2
+    integer, intent(in), optional :: first
+    integer                       :: foundIndex
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    foundIndex = vstring_last_vstring ( this , vstring2 , first )
+    call vstring_free ( vstring2 )
+  end function vstring_last_charstring
+  !
+  ! vstring_range --
+  !   Returns a range of consecutive characters from string,
+  !   starting with the character whose index is first and ending with the character whose
+  !   index is last. An index of 1 refers to the first character of the string.
+  !   If first is less than 1 then an error is generated.
+  !   If last is greater than or equal to the length of the string then an error is generated.
+  !   If first is greater than last then an error is generated.
+  ! TODO : first and last may be specified as for the index method.
+  !
+  function vstring_range ( this , first , last ) result ( string_range )
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(in)         :: first , last
+    type(t_vstring)             :: string_range
+    character ( len = 200) :: message
+    integer :: status
+    call vstring_check_string ( this , "vstring_range" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_index ( this , first , "vstring_range" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_index ( this , last , "vstring_range" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if ( first > last ) then
+       write ( message , * ) "First index ", first , " is greater than last ", last, &
+            " in vstring_range"
+       call vstring_error ( this , message )
+    endif
+    call vstring_new ( string_range , this % chars ( first : last ) )
+  end function vstring_range
+  !
+  ! vstring_index --
+  !   Returns the charIndex'th character of the string argument.
+  !   A charIndex of 1 corresponds to the first character of the string.
+  !   If charIndex is less than 1 or greater than or equal to the length of the string
+  !   then an error is generated.
+  ! TODO : index can be given as the string "end" and corresponds to the last char of the string.
+  !
+  function vstring_index ( this , charIndex ) result ( string_index )
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(in)         :: charIndex
+    type(t_vstring)             :: string_index
+    integer :: status
+    call vstring_check_string ( this , "vstring_index" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_index ( this , charIndex , "vstring_index" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_new ( string_index , this % chars ( charIndex : charIndex ) )
+  end function vstring_index
+  !
+  ! vstring_toupper --
+  !   Returns a vstring except that all lower (or title) case letters have been
+  !   converted to upper case. If first is specified, it refers to the first char index in the string
+  !   to start modifying. If last is specified, it refers to the char index in the string to stop
+  !   at (inclusive).
+  !
+  function vstring_toupper ( this , first , last ) result ( new_upper )
+    type ( t_vstring ) , intent(in) :: this
+    integer , intent ( in ), optional :: first
+    integer , intent ( in ), optional :: last
+    type(t_vstring) :: new_upper
+    integer :: first_real
+    integer :: last_real
+    integer :: icharacter
+    integer :: firstindex
+    integer :: status
+    !
+    ! Get options
+    !
+    call vstring_check_string ( this , "vstring_toupper" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    if (present( first )) then
+       call vstring_check_index ( this , first , "vstring_toupper" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       first_real = first
+    else
+       first_real = 1
+    endif
+    if (present( last )) then
+       call vstring_check_index ( this , last , "vstring_toupper" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       last_real = last
+    else
+       last_real = vstring_length ( this )
+    endif
+    !
+    ! Compute the upper case string.
+    !
+    call vstring_new ( new_upper , this )
+    do icharacter = first_real , last_real
+       firstindex = index( VSTRING_LOWER , this % chars ( icharacter)  )
+       if ( firstindex > 0 ) then
+          new_upper % chars ( icharacter ) = VSTRING_UPPER ( firstindex : firstindex )
+       endif
+
+    enddo
+  end function vstring_toupper
+  !
+  ! vstring_tolower --
+  !   Returns a vstring except that all upper (or title) case letters have been
+  !   converted to lower case. If first is specified, it refers to the first char index in the string
+  !   to start modifying. If last is specified, it refers to the char index in the string to stop
+  !   at (inclusive).
+  !
+  function vstring_tolower ( this , first , last ) result ( new_lower )
+    type ( t_vstring ) , intent(in) :: this
+    integer , intent ( in ), optional :: first
+    integer , intent ( in ), optional :: last
+    type(t_vstring) :: new_lower
+    integer :: first_real
+    integer :: last_real
+    integer :: icharacter
+    integer :: firstindex
+    integer :: length
+    integer :: status
+    !
+    ! Get options
+    !
+    call vstring_check_string ( this , "vstring_tolower" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    length = vstring_length ( this )
+    if (present( first )) then
+       call vstring_check_index ( this , first , "vstring_tolower" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       first_real = first
+    else
+       first_real = 1
+    endif
+    if (present( last )) then
+       call vstring_check_index ( this , last , "vstring_tolower" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       last_real = last
+    else
+       last_real = length
+    endif
+    !
+    ! Compute the lower case string.
+    !
+    call vstring_new ( new_lower , this )
+    do icharacter = first_real , last_real
+       firstindex = index( VSTRING_UPPER , this % chars ( icharacter)  )
+       if ( firstindex > 0 ) then
+          new_lower % chars ( icharacter ) = VSTRING_LOWER ( firstindex : firstindex )
+       endif
+    enddo
+  end function vstring_tolower
+  !
+  ! vstring_totitle --
+  !   Returns a vstring except that the first character in string is converted
+  !   to upper case, and the rest of the string is converted to lower case. If first is specified, it refers
+  !   to the first char index in the string to start modifying. If last is specified, it refers
+  !   to the char index in the string to stop at (inclusive).
+  !
+  function vstring_totitle ( this , first , last ) result ( new_title )
+    type ( t_vstring ) , intent(in) :: this
+    integer , intent ( in ), optional :: first
+    integer , intent ( in ), optional :: last
+    type(t_vstring) :: new_title
+    integer :: first_real
+    integer :: last_real
+    integer :: length
+    integer :: status
+    !
+    ! The new string is made of 4 parts :
+    ! - before the first letter to update (left unchanged)
+    ! - the letter to upper case
+    ! - the sub-part to lower case
+    ! - after the last letter to update (left unchanged)
+    !
+    type(t_vstring) :: subpart1
+    type(t_vstring) :: subpart2
+    type(t_vstring) :: subpart3
+    type(t_vstring) :: subpart4
+    type(t_vstring) :: subpartToUpper
+    type(t_vstring) :: subpartToLower
+    call vstring_check_string ( this , "vstring_totitle" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    !
+    ! Get options
+    !
+    if (present( first )) then
+       call vstring_check_index ( this , first , "vstring_totitle" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+       first_real = first
+    else
+       first_real = 1
+    endif
+    length = vstring_length ( this )
+    if (present( last )) then
+       call vstring_check_index ( this , last , "vstring_totitle" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+       last_real = last
+    else
+       last_real = length
+    endif
+    !
+    ! Compute subpart1
+    !
+    if ( first_real > 1 ) then
+       subpart1 = vstring_range ( this , 1 , first_real - 1 )
+    else
+       call vstring_new ( subpart1 , "" )
+    endif
+    !
+    ! Compute subpart2
+    !
+    if ( length > 0 ) then
+       subpartToUpper = vstring_index ( this , first_real )
+       subpart2 = vstring_toupper ( subpartToUpper )
+       call vstring_free ( subpartToUpper )
+    else
+       call vstring_new ( subpart2 , "" )
+    endif
+    !
+    ! Compute subpart3
+    !
+    if ( first_real + 1 <= last_real ) then
+       subpartToLower = vstring_range ( this , first_real + 1, last_real )
+       subpart3 = vstring_tolower ( subpartToLower )
+       call vstring_free ( subpartToLower )
+    else
+       call vstring_new ( subpart3 , "" )
+    endif
+    !
+    ! Compute subpart4
+    !
+    if ( last_real + 1 <= length ) then
+       subpart4 = vstring_range ( this , last_real + 1 , length )
+    else
+       call vstring_new ( subpart4 , "" )
+    endif
+    !
+    ! Concatenate the sub-parts
+    !
+    call vstring_new ( new_title , subpart1 )
+    call vstring_append ( new_title , subpart2 )
+    call vstring_append ( new_title , subpart3 )
+    call vstring_append ( new_title , subpart4 )
+    !
+    ! Cleanup
+    !
+    call vstring_free ( subpart1 )
+    call vstring_free ( subpart2 )
+    call vstring_free ( subpart3 )
+    call vstring_free ( subpart4 )
+  end function vstring_totitle
+  !
+  ! vstring_reverse --
+  !   Return a string that has all characters in reverse order
+  ! Arguments:
+  !   this     The current object
+  ! Result:
+  !   Reversed string
+  !
+  function vstring_reverse ( this ) result ( new_reverse )
+    type ( t_vstring ) , intent(in) :: this
+    type(t_vstring) :: new_reverse
+    integer :: icharacter
+    integer :: length
+    integer :: status
+    call vstring_check_string ( this , "vstring_reverse" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    length = vstring_length ( this )
+    call vstring_new ( new_reverse , this )
+    do icharacter = 1 , length
+       new_reverse % chars ( icharacter ) = this % chars ( length - icharacter + 1 )
+    enddo
+  end function vstring_reverse
+  !
+  ! vstring_random --
+  !   Fill a string with required length and randomized characters.
+  ! Arguments:
+  !   length : the length of the random string to compute.
+  ! Result:
+  !   String with random letters
+  ! Note :
+  !   This is a static method.
+  !
+  function vstring_random ( length ) result ( new_random )
+    integer, intent(in) :: length
+    type(t_vstring) :: new_random
+    integer :: icharacter
+    integer :: random_integer
+    integer :: setsize
+    real :: alea
+    type(t_vstring) :: characterset
+    !
+    ! Initialize
+    !
+    setsize = len ( VSTRING_CHARACTERSET )
+    call vstring_new ( characterset , VSTRING_CHARACTERSET )
+    call vstring_new ( new_random , length )
+    if ( .NOT.random_process_initialize ) then
+       call random_seed()
+       random_process_initialize = .true.
+    endif
+    !
+    ! Compute each random character
+    !
+    do icharacter = 1 , length
+       call random_number ( alea )
+       random_integer = nint( alea * setsize + 1 - alea )
+       new_random % chars ( icharacter ) = characterset % chars ( random_integer )
+    enddo
+    !
+    ! Cleanup
+    !
+    call vstring_free ( characterset )
+  end function vstring_random
+  !
+  ! vstring_match_vstring --
+  !   See if pattern matches string; return 1 if it does, 0 if it doesn't.
+  !   If -nocase is specified, then the pattern attempts to match against the
+  !   string in a case insensitive manner.
+  !   For the two strings to match, their contents must be identical except
+  !   that the following special sequences may appear in pattern:
+  !     *
+  !       Matches any sequence of characters in string, including a null string.
+  !     ?
+  !       Matches any single character in string.
+  !     [chars]
+  !       Matches any character in the set given by chars.
+  !       If a sequence of the form x-y appears in chars, then any character
+  !       between x and y, inclusive, will match.
+  !       When used with -nocase, the characters of the range are converted to lower case first.
+  !       Whereas {[A-z]} matches '_' when matching case-sensitively ('_' falls between the 'Z'
+  !       and 'a'), with -nocase this is considered like {[A-Za-z]} (and probably what was
+  !       meant in the first place).
+  !     \x
+  !       Matches the single character x.
+  !       This provides a way of avoiding the special interpretation of the characters *?[]\ in pattern.
+  !
+  recursive function vstring_match_vstring ( this , pattern , nocase ) result ( match )
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: pattern
+    logical , intent(in) , optional :: nocase
+    logical :: match
+    logical :: equals
+    type(t_vstring) :: backslash
+    type(t_vstring) :: question
+    type(t_vstring) :: this_char1
+    type(t_vstring) :: pattern_char1
+    type(t_vstring) :: charstar
+    type(t_vstring) :: leftbracket
+    type(t_vstring) :: rightbracket
+    integer :: this_length
+    integer :: pattern_length
+    type(t_vstring) :: this_substring
+    type(t_vstring) :: pattern_substring
+    type(t_vstring) :: pattern_char2
+    type(t_vstring) :: pattern_substring2
+    integer :: first
+    integer :: firstrightbracket
+    type(t_vstring) :: chars
+    type(t_vstring) :: expanded
+    logical :: nocase_real
+    type(t_vstring) :: this_char1lower
+    type(t_vstring) :: chars_lower
+    integer :: status
+
+    match = .false.
+
+    !
+    ! Process options
+    !
+    if ( present ( nocase ) ) then
+       nocase_real = nocase
+    else
+       nocase_real = .false.
+    endif
+    !
+    ! Initialize
+    !
+    call vstring_check_string ( this , "Check string in vstring_match_vstring." , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( pattern , "Check pattern in vstring_match_vstring." , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_new ( charstar , "*" )
+    call vstring_new ( backslash , "\" )
+    call vstring_new ( question , "?" )
+    call vstring_new ( leftbracket , "[" )
+    call vstring_new ( rightbracket , "]" )
+    this_length = vstring_length ( this )
+    pattern_length = vstring_length ( pattern )
+    !
+    ! Get various parts of the current string and the pattern :
+    ! - first char,
+    ! - everything from the 2 to the end.
+    !
+    if ( this_length > 0 ) then
+       this_char1 = vstring_index ( this , 1 )
+    else
+       call vstring_new ( this_char1 , "" )
+    endif
+    if ( pattern_length > 0 ) then
+       pattern_char1 = vstring_index ( pattern , 1 )
+    else
+       call vstring_new ( pattern_char1, "" )
+    endif
+    if ( this_length > 1 ) then
+       this_substring = vstring_range ( this , 2 , this_length )
+    else
+       call vstring_new ( this_substring , "" )
+    endif
+    if ( pattern_length > 1 ) then
+       pattern_substring = vstring_range ( pattern , 2 , pattern_length )
+    else
+       call vstring_new ( pattern_substring , "" )
+    endif
+    !
+    ! This is a chain of tests :
+    ! the first test which returns .true. breaks the chain.
+    !
+    match = .false.
+    do
+       !
+       ! Process the strict equality between string and pattern
+       !
+       match = vstring_equals ( this , pattern , nocase = nocase_real )
+       if ( match ) then
+          exit
+       endif
+       !
+       ! Process the case where the first character of the pattern is a "\".
+       !
+       equals = vstring_equals ( backslash , pattern_char1 )
+       if ( equals ) then
+          !
+          ! Compare the second character of the pattern against the first character of the string.
+          !
+          if ( pattern_length > 1 ) then
+             pattern_char2 = vstring_index ( pattern , 2 )
+             equals = vstring_equals ( this_char1 , pattern_char2 , nocase = nocase_real )
+             call vstring_free ( pattern_char2 )
+             if ( equals ) then
+                if ( pattern_length > 2 ) then
+                   pattern_substring2 = vstring_range ( pattern , 3 , pattern_length )
+                else
+                   call vstring_new ( pattern_substring2 , "" )
+                endif
+                match = vstring_match_vstring ( this_substring , pattern_substring2 , nocase = nocase_real )
+                call vstring_free ( pattern_substring2 )
+                if ( match ) then
+                   exit
+                endif
+             endif
+          endif
+       endif
+       !
+       ! Process the case where the first character of the pattern is a "*"
+       !
+       equals = vstring_equals ( charstar , pattern_char1 )
+       if ( equals ) then
+          !
+          ! Solution #1 : Compare the string against the end of the pattern
+          !
+          match = vstring_match_vstring ( this , pattern_substring , nocase = nocase_real )
+          if ( match ) then
+             exit
+          endif
+          !
+          ! Solution #2 : The string is empty and the subpattern after the "*" does not match.
+          ! => There is no match at all.
+          ! Note: this_substring is therefore empty and solution #3 would generate a infinite loop.
+          !
+          if ( this_length == 0 ) then
+             exit
+          endif
+          !
+          ! Solution #3 : Compare the end of the string against the pattern
+          !
+          match = vstring_match_vstring ( this_substring , pattern , nocase = nocase_real )
+          if ( match ) then
+             exit
+          endif
+       endif
+       !
+       ! Process the case where the first character of the pattern is a "?"
+       ! If the current string is of length 0, there is no match.
+       !
+       equals = vstring_equals ( question , pattern_char1 )
+       if ( equals .AND. this_length > 0 ) then
+          !
+          ! Compare the end of the string against the end of the pattern.
+          !
+          match = vstring_match_vstring ( this_substring , pattern_substring , nocase = nocase_real )
+          if ( match ) then
+             exit
+          endif
+       endif
+       !
+       ! Process the case where the first character of the pattern is a "[".
+       ! It is followed by a list of characters that are acceptable, or by a range
+       ! (two characters separated by "-").
+       ! It is ended by a "]".
+       !
+       equals = vstring_equals ( leftbracket , pattern_char1 )
+       if ( equals ) then
+          !
+          ! Search for the corresponding right bracket "]"
+          !
+          firstrightbracket = vstring_first ( pattern , rightbracket )
+          if ( firstrightbracket > 2 ) then
+             !
+             ! Get the characters in the set.
+             !
+             chars = vstring_range ( pattern , 2 , firstrightbracket - 1 )
+             if ( nocase_real ) then
+                chars_lower = vstring_tolower ( chars )
+                call vstring_free ( chars )
+                call vstring_new ( chars , chars_lower )
+                call vstring_free ( chars_lower )
+             endif
+             !
+             ! Expand the character set, by taking into account for character ranges defined with "-".
+             !
+             expanded = vstring_expandcharset ( chars )
+             call vstring_free ( chars )
+             !
+             ! Search the first char of the current string in the expanded set of characters
+             !
+             if ( nocase_real ) then
+                this_char1lower = vstring_tolower ( this_char1 )
+                first = vstring_first ( expanded , this_char1lower )
+                call vstring_free ( this_char1lower )
+             else
+                first = vstring_first ( expanded , this_char1 )
+             endif
+             call vstring_free ( expanded )
+             if ( first > 0 ) then
+                !
+                ! Compare the end of the string to the end of the pattern
+                !
+                if ( pattern_length > firstrightbracket ) then
+                   pattern_substring2 = vstring_range ( pattern , firstrightbracket + 1 , pattern_length )
+                else
+                   call vstring_new ( pattern_substring2 , "" )
+                endif
+                match = vstring_match_vstring ( this_substring , pattern_substring2 , nocase = nocase_real )
+                call vstring_free ( pattern_substring2 )
+                if ( match ) then
+                   exit
+                endif
+             endif
+          endif
+       endif
+       !
+       ! The first letter is not a special character.
+       ! There is a match if the first letters are the same
+       ! and the end of both string and pattern match.
+       !
+       equals = vstring_equals ( this_char1 , pattern_char1 , nocase = nocase_real )
+       if ( equals ) then
+          !
+          ! Compare the end of the string against the end of the pattern
+          !
+          match = vstring_match_vstring ( this_substring , pattern_substring , nocase = nocase_real )
+          if ( match ) then
+             exit
+          endif
+       endif
+       !
+       ! No test match
+       !
+       exit
+    enddo
+    call vstring_free ( charstar )
+    call vstring_free ( backslash )
+    call vstring_free ( question )
+    call vstring_free ( this_char1 )
+    call vstring_free ( pattern_char1 )
+    call vstring_free ( this_substring )
+    call vstring_free ( pattern_substring )
+    call vstring_free ( leftbracket )
+    call vstring_free ( rightbracket )
+  end function vstring_match_vstring
+  !
+  ! vstring_match_charstring --
+  !   Interface to vstring_match_vstring to manage character strings.
+  !
+  recursive function vstring_match_charstring ( this , pattern , nocase ) result ( match )
+    type ( t_vstring ) , intent(in) :: this
+    character(len=*), intent(in) :: pattern
+    logical , intent(in) , optional :: nocase
+    logical :: match
+    type(t_vstring) :: vpattern
+    call vstring_new ( vpattern , pattern )
+    match = vstring_match_vstring ( this , vpattern , nocase )
+    call vstring_free ( vpattern )
+  end function vstring_match_charstring
+  !
+  ! vstring_expandcharset --
+  !   Consider that the current string is a character set and returns
+  !   the expanded form of that set.
+  !   The expanded form of the character set "abc" is "abc".
+  !   If a sequence of the form x-y appears in the current string, then the expanded form
+  !   contains all characters between x and y, inclusive.
+  !   For example, if the current string is "a-z", the returned expanded set is made
+  !   of all the lower case letters.
+  !   For example, if the current string is "a-zA-Z", the returned expanded set is made
+  !   of all the lower case letters and upper case letters.
+  !   For example, if the current string is "a-zA-Z_", the returned expanded set is made
+  !   of all the lower case letters and upper case letters and underscore.
+  !
+  recursive function vstring_expandcharset ( this ) result ( expanded )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    type(t_vstring) :: expanded
+    type(t_vstring) :: minus
+    integer :: firstminus
+    type(t_vstring) :: startchar
+    type(t_vstring) :: endchar
+    integer :: this_length
+    integer :: startascii
+    integer :: endascii
+    integer :: iascii
+    type(t_vstring) :: asciichar
+    type(t_vstring) :: this_substring
+    type(t_vstring) :: expanded_end
+    integer :: status
+    !
+    ! Initialize
+    !
+    call vstring_check_string ( this , "vstring_expandcharset" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_new ( minus , "-" )
+    this_length = vstring_length ( this )
+    !
+    ! Compute expanded character set
+    !
+    firstminus = vstring_first ( this , minus )
+    if ( firstminus == 2 .AND. this_length >= 3) then
+       !
+       ! Add the current range to the expanded set.
+       !
+       startchar = vstring_index ( this , 1 )
+       endchar = vstring_index ( this , 3 )
+       startascii = vstring_iachar ( startchar )
+       endascii = vstring_iachar ( endchar )
+       !
+       ! Add the the character set all character which ascii index is between start and end.
+       !
+       call vstring_new ( expanded , "" )
+       do iascii = startascii , endascii
+          asciichar = vstring_char ( iascii )
+          call vstring_append ( expanded , asciichar )
+          call vstring_free ( asciichar )
+       enddo
+       call vstring_free ( startchar )
+       call vstring_free ( endchar )
+       !
+       ! Expand the end of the character set.
+       !
+       if ( this_length > 3 ) then
+          this_substring = vstring_range ( this , 4 , this_length )
+          expanded_end = vstring_expandcharset ( this_substring )
+          call vstring_append ( expanded , expanded_end )
+          call vstring_free ( expanded_end )
+          call vstring_free ( this_substring )
+       endif
+    else
+       call vstring_new ( expanded , this )
+    endif
+    !
+    ! Clean-up
+    !
+    call vstring_free ( minus )
+  end function vstring_expandcharset
+  !
+  ! vstring_is --
+  !   Returns .true. if string is a valid member of the specified character class,
+  !   otherwise returns .false..
+  !   If strict is provided and .true., then an empty string returns .false..
+  !   If strict is provided and .false., or not provided, an empty string returns .true..
+  !   If failindex is provided, then if the function returns .false., the index in the
+  !   string where the class was no longer valid will be stored in the variable failindex.
+  !   The following character classes are recognized (the class name can be abbreviated):
+  !     alpha
+  !         Any alphabet character, that is [a-zA-Z].
+  !     alnum
+  !         Any alphabet or digit character, that is [a-zA-Z0-9].
+  !     ascii
+  !         Any character with a value less than 128 (those that are in the 7-bit ascii range).
+  !     control
+  !         Any control character. Control chars are in the
+  !         ranges 00..1F and 7F..9F, that is from ascii #0 to #31 and from #127 to #159
+  !     digit
+  !         Any digit character. Note that this includes characters outside of the [0-9] range.
+  !     false
+  !         Any of the forms allowed where the logical is false.
+  !     graph
+  !         Any printing character, except space that is from ascii #33 to #126.
+  !     integer
+  !         Any of the valid forms for an ordinary integer in Fortran, with optional surrounding whitespace.
+  !     logical
+  !         Any valid Fortran logical
+  !     lower
+  !         Any lower case alphabet character, that is [a-z].
+  !     punct
+  !         Any punctuation character, that is _,;:.?![](){}@"'
+  !     print
+  !         Any printing character, including space that is from ascii #32 to #126.
+  !     real
+  !         Any of the valid forms for a real in Fortran, with optional surrounding whitespace.
+  !     space
+  !         Any space character, that is white space, tab, newline or carriage return.
+  !     true
+  !         Any of the forms allowed where the logical is true.
+  !     upper
+  !         Any upper case alphabet character, that is [A-Z].
+  !     xdigit
+  !         Any hexadecimal digit character ([0-9A-Fa-f]).
+  !     wordchar
+  !         Any word character. That is any alphanumeric character (upper case,
+  !         lower case, or digit), or any connector punctuation characters (e.g. underscore).
+  ! Note
+  !   This implementation is based on vstring_isincharset and vstring_isinasciirange.
+  !
+   function vstring_is ( this , class , strict , failindex ) result ( isinclass )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    character(len=*), intent(in) :: class
+    logical, intent(in) , optional :: strict
+    integer, intent(out) , optional :: failindex
+    logical :: isinclass
+    character(len=200) :: message
+    logical :: strict_real
+    integer :: length
+    integer :: failindex_real
+    !
+    ! Process options
+    !
+    if ( present ( strict ) ) then
+       strict_real = strict
+    else
+       strict_real = .false.
+    endif
+    !
+    ! By default, it is of no class
+    !
+    isinclass = .false.
+    !
+    ! Now search a class
+    !
+    if ( class == "digit" ) then
+       isinclass = vstring_isdigit ( this , failindex_real )
+    elseif ( class == "integer" ) then
+       isinclass = vstring_isinteger ( this , failindex_real )
+    elseif ( class == "alpha" ) then
+       isinclass = vstring_isalpha ( this , failindex_real )
+    elseif ( class == "alnum" ) then
+       isinclass = vstring_isalnum ( this , failindex_real )
+    elseif ( class == "logical" ) then
+       isinclass = vstring_islogical ( this , failindex_real )
+    elseif ( class == "real" ) then
+       isinclass = vstring_isreal ( this , failindex_real )
+    elseif ( class == "true" ) then
+       isinclass = vstring_istrue ( this , failindex_real )
+    elseif ( class == "false" ) then
+       isinclass = vstring_isfalse ( this , failindex_real )
+    elseif ( class == "lower" ) then
+       isinclass = vstring_islower ( this , failindex_real )
+    elseif ( class == "upper" ) then
+       isinclass = vstring_isupper ( this , failindex_real )
+    elseif ( class == "space" ) then
+       isinclass = vstring_isspace ( this , failindex_real )
+    elseif ( class == "punct" ) then
+       isinclass = vstring_ispunct ( this , failindex_real )
+    elseif ( class == "xdigit" ) then
+       isinclass = vstring_isxdigit ( this , failindex_real )
+    elseif ( class == "ascii" ) then
+       isinclass = vstring_isascii ( this , failindex_real )
+    elseif ( class == "control" ) then
+       isinclass = vstring_iscontrol ( this , failindex_real )
+    elseif ( class == "print" ) then
+       isinclass = vstring_isprint ( this , failindex_real )
+    elseif ( class == "graph" ) then
+       isinclass = vstring_isgraph ( this , failindex_real )
+    elseif ( class == "wordchar" ) then
+       isinclass = vstring_iswordchar ( this , failindex_real )
+    else
+       write ( message , * ) "Unknown class:" , class
+       call vstring_error ( this , message , "vstring_is" )
+    endif
+    !
+    ! Process the special case where the string is empty.
+    ! Caution !
+    !   This is done after all other tests, to make sure that the class is known.
+    !
+    length = vstring_length ( this )
+    if ( length == 0 ) then
+       if ( strict_real ) then
+          isinclass = .false.
+       else
+          isinclass = .true.
+       endif
+    endif
+    !
+    ! Get failing index
+    !
+    if ( present ( failindex ) ) then
+       failindex = failindex_real
+    endif
+
+  end function vstring_is
+  !
+  ! vstring_isdigit --
+  !   Returns 1 if string is a valid digit.
+  !
+  logical function vstring_isdigit ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_DIGITS )
+    vstring_isdigit = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isdigit
+  !
+  ! vstring_isinteger --
+  !   Returns 1 if string is a valid integer, with optional surrounding whitespace.
+  !
+  logical function vstring_isinteger ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_DIGITS )
+    call vstring_append ( characterset , VSTRING_SPACE )
+    vstring_isinteger = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isinteger
+  !
+  ! vstring_isalpha --
+  !   Returns 1 if string is a alphabet character.
+  !
+  logical function vstring_isalpha ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_LOWER )
+    call vstring_append ( characterset , VSTRING_UPPER )
+    vstring_isalpha = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isalpha
+  !
+  ! vstring_isalnum --
+  !   Returns 1 if string is a alphabet or digit character.
+  !
+  logical function vstring_isalnum ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_LOWER )
+    call vstring_append ( characterset , VSTRING_UPPER )
+    call vstring_append ( characterset , VSTRING_DIGITS )
+    vstring_isalnum = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isalnum
+  !
+  ! vstring_islogical --
+  !   Returns .true. if string is a valid logical
+  !
+  logical function vstring_islogical ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    logical :: mylogical
+    ! 7 is the largest possible length of a logical.
+    character ( len = 7 ) :: logicalstring
+    call vstring_cast ( this , logicalstring )
+    read ( logicalstring , * , err = 100 ) mylogical
+    vstring_islogical = .true.
+    return
+100 continue
+    ! This is not a logical
+    vstring_islogical = .false.
+    ! TODO : compute a finer value for failindex
+    failindex = 1
+  end function vstring_islogical
+  !
+  ! vstring_isreal --
+  !   Returns .true. if string is a valid real
+  !
+  logical function vstring_isreal ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    real :: mydata
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: charstring
+#else
+    character ( len = vstring_length ( this ) ) :: charstring
+#endif
+    call vstring_cast ( this , charstring )
+    read ( charstring , * , err = 100 ) mydata
+    vstring_isreal = .true.
+    failindex = VSTRING_INDEX_UNKNOWN
+    return
+100 continue
+    ! This is not a real
+    vstring_isreal = .false.
+    ! TODO : compute a finer value for failindex
+    failindex = 1
+  end function vstring_isreal
+  !
+  ! vstring_istrue --
+  !   Returns .true. if string is a valid logical true value
+  !
+  logical function vstring_istrue ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    logical :: mylogical
+    character ( len = 7 ) :: logicalstring
+    call vstring_cast ( this , logicalstring )
+    read ( logicalstring , * , err = 100 ) mylogical
+    vstring_istrue = mylogical
+    ! TODO : compute a finer value for failindex
+    if ( vstring_istrue ) then
+       failindex = VSTRING_INDEX_UNKNOWN
+    else
+       failindex = 1
+    endif
+    return
+100 continue
+    ! This is not a logical
+    vstring_istrue = .false.
+    ! TODO : compute a finer value for failindex
+    failindex = 1
+  end function vstring_istrue
+  !
+  ! vstring_isfalse --
+  !   Returns .true. if string is a valid logical false value
+  !
+  logical function vstring_isfalse ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    logical :: mylogical
+    character ( len = 7 ) :: logicalstring
+    call vstring_cast ( this , logicalstring )
+    read ( logicalstring , * , err = 100 ) mylogical
+    vstring_isfalse = .NOT.mylogical
+    if ( vstring_isfalse ) then
+       failindex = VSTRING_INDEX_UNKNOWN
+    else
+       failindex = 1
+    endif
+    return
+100 continue
+    ! This is not a logical
+    vstring_isfalse = .false.
+    ! TODO : compute a finer value for failindex
+    failindex = 1
+  end function vstring_isfalse
+  !
+  ! vstring_islower --
+  !   Returns .true. if string is a valid lower case character
+  !
+  logical function vstring_islower ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_LOWER )
+    vstring_islower = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_islower
+  !
+  ! vstring_isupper --
+  !   Returns .true. if string is a valid upper case character
+  !
+  logical function vstring_isupper ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_UPPER )
+    vstring_isupper = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isupper
+  !
+  ! vstring_isspace --
+  !   Returns .true. if string is a valid space character
+  !
+  logical function vstring_isspace ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_WHITESPACE )
+    vstring_isspace = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isspace
+  !
+  ! vstring_ispunct --
+  !   Returns .true. if string is a valid punctuation character
+  !
+  logical function vstring_ispunct ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_PUNCTUATION )
+    vstring_ispunct = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_ispunct
+  !
+  ! vstring_isxdigit --
+  !   Returns .true. if string is a valid hexadecimal string
+  !
+  logical function vstring_isxdigit ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset , VSTRING_HEXDIGITS )
+    vstring_isxdigit = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_isxdigit
+  !
+  ! vstring_isascii --
+  !   Returns .true. if string is a valid ascii string
+  !
+  logical function vstring_isascii ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    vstring_isascii = vstring_isinasciirange ( this , 0 , 127 , failindex )
+  end function vstring_isascii
+  !
+  ! vstring_iscontrol --
+  !   Returns .true. if string is a valid control string
+  ! Note
+  !   From ascii #0 to #31 and from #127 to #159.
+  !
+  logical function vstring_iscontrol ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    logical :: isinrange1
+    logical :: isinrange2
+    isinrange1 = vstring_isinasciirange ( this , 0 , 31 , failindex )
+    isinrange2 = vstring_isinasciirange ( this , 127 , 159 , failindex )
+    if ( isinrange1 ) then
+       ! This is control
+       vstring_iscontrol = .true.
+    elseif ( isinrange2 ) then
+       ! This is control
+       vstring_iscontrol = .true.
+    else
+       ! This is not control
+       vstring_iscontrol = .false.
+    endif
+  end function vstring_iscontrol
+  !
+  ! vstring_isprint --
+  !   Returns .true. if string is a valid print string, including white space
+  ! Note
+  !   From ascii #32 to #126
+  !
+  logical function vstring_isprint ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    vstring_isprint = vstring_isinasciirange ( this , 32 , 126 , failindex )
+  end function vstring_isprint
+  !
+  ! vstring_isgraph --
+  !   Returns .true. if string is a valid print string, excluding white space
+  ! Note
+  !   From ascii #33 to #126
+  !
+  logical function vstring_isgraph ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    vstring_isgraph = vstring_isinasciirange ( this , 33 , 126 , failindex )
+  end function vstring_isgraph
+  !
+  ! vstring_iswordchar --
+  !   Returns .true. if string is a valid wordchar character
+  !
+  logical function vstring_iswordchar ( this , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(out) :: failindex
+    type(t_vstring) :: characterset
+    call vstring_new ( characterset )
+    call vstring_append ( characterset , VSTRING_LOWER )
+    call vstring_append ( characterset , VSTRING_UPPER )
+    call vstring_append ( characterset , VSTRING_DIGITS )
+    call vstring_append ( characterset , VSTRING_PUNCTUATION )
+    vstring_iswordchar = vstring_isincharset ( this , characterset , failindex )
+    call vstring_free ( characterset )
+  end function vstring_iswordchar
+  !
+  ! vstring_isincharset --
+  !   Returns .true. if string is made of characters which all are in the
+  !   given character set.
+  !   If failingindex is provided and the string in not in the character set,
+  !   the integer failingindex is the index in the string where the
+  !   character is not in the set.
+  ! Note
+  !   This is an alternative implementation for vstring_verify.
+  ! Arguments
+  !   characterset The character set.
+  !   failindex The index of the first character not in the set.
+  !
+  logical function vstring_isincharset ( this , characterset , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: characterset
+    integer, intent(out), optional :: failindex
+    integer :: icharacter
+    integer :: length
+    type(t_vstring) :: currentchar
+    integer :: charindex
+    !
+    ! Initialize
+    !
+    length = vstring_length ( this )
+    !
+    ! By default, it is in the character set.
+    !
+    vstring_isincharset = .true.
+    !
+    ! Now find the cases when it is not in the character set.
+    !
+    do icharacter = 1 , length
+       currentchar = vstring_index ( this , icharacter )
+       charindex = vstring_first ( characterset , currentchar )
+       call vstring_free ( currentchar )
+       if ( charindex == VSTRING_INDEX_UNKNOWN ) then
+          vstring_isincharset = .false.
+          exit
+       endif
+    enddo
+    !
+    ! Process failing index
+    !
+    if ( present ( failindex ) ) then
+       if ( vstring_isincharset ) then
+          failindex = VSTRING_INDEX_UNKNOWN
+       else
+          failindex = icharacter
+       endif
+    endif
+  end function vstring_isincharset
+  !
+  ! vstring_isinasciirange --
+  !   Returns .true. if string is in the given ascii range from min to max.
+  !
+  logical function vstring_isinasciirange ( this , asciimin , asciimax , failindex )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer , intent(in) :: asciimin , asciimax
+    integer, intent(out), optional :: failindex
+    integer :: icharacter
+    integer :: length
+    type(t_vstring) :: currentchar
+    integer :: charindex
+    !
+    ! Initialize
+    !
+    length = vstring_length ( this )
+    !
+    ! By default, it is in the ascii character set.
+    !
+    vstring_isinasciirange = .true.
+    !
+    ! Now find the cases when it is not in the character set.
+    !
+    do icharacter = 1 , length
+       currentchar = vstring_index ( this , icharacter )
+       charindex = vstring_iachar ( currentchar )
+       call vstring_free ( currentchar )
+       if ( charindex < asciimin .OR. charindex > asciimax ) then
+          ! This is not in the range
+          vstring_isinasciirange = .false.
+          exit
+       endif
+    enddo
+    !
+    ! Process failindex
+    !
+    if ( present ( failindex ) ) then
+       if ( vstring_isinasciirange ) then
+          failindex = VSTRING_INDEX_UNKNOWN
+       else
+          failindex = icharacter
+       endif
+    endif
+  end function vstring_isinasciirange
+
+  ! vstring_append_vstring --
+  !   Append the given string at the end of the current string.
+  !   If the given string (string2) is of length greater than zero,
+  !   that means that the length of the current string will be greater
+  !   after the call to vstring_append.
+  ! Note
+  !   That method can be called as a convenient alternative to vstring_concat,
+  !   when the concat is to be done "in place".
+  !
+  subroutine vstring_append_vstring ( this , string2 )
+    type ( t_vstring ) , intent(inout) :: this
+    type ( t_vstring ) , intent(in) :: string2
+    type(t_vstring) :: old_string
+    integer :: status
+    call vstring_check_string ( this , "vstring_append_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_string ( string2 , "vstring_append_vstring" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_new ( old_string , this )
+    call vstring_free ( this )
+    this = vstring_concat ( old_string , string2 )
+    call vstring_free ( old_string )
+  end subroutine vstring_append_vstring
+  !
+  ! vstring_append_charstring --
+  !   Interface to manage character strings
+  !
+  subroutine vstring_append_charstring ( this , string2 )
+    type ( t_vstring ) , intent(inout) :: this
+    character(len=*), intent(in) :: string2
+    type(t_vstring) :: vstring2
+    call vstring_new ( vstring2 , string2 )
+    call vstring_append_vstring ( this , vstring2 )
+    call vstring_free ( vstring2 )
+  end subroutine vstring_append_charstring
+  !
+  ! vstring_map --
+  !   Replaces substrings in string based on the mapping defined by the couple (map_old , map_new).
+  !   map_old and map_new are arrays of vstrings and are of the same size so that
+  !   if imap is an index no greater than the size of map_old,
+  !   map_old ( imap ) is the old string and map_new ( imap ) is the new string.
+  !   Each instance of a key in the string will be replaced with its corresponding value.
+  !   Both old and new strings may be multiple characters.
+  !   If nocase is set to .true., then matching is done without regard to case differences.
+  !   Replacement is done in an ordered manner, so the old string appearing first
+  !   in the list will be checked first, and so on. The current string is only iterated over once,
+  !   so earlier replacements will have no affect for later matches.
+  !   For example,
+  !     vstring_map 1abcaababcabababc [abc,ab,a,1] [1,2,3,0]
+  !   will return the string 01321221.
+  !   Note that if an earlier key is a prefix of a later one, it will completely
+  !   mask the later one. So if the previous example is reordered like this,
+  !     vstring_map 1abcaababcabababc [1,ab,a,abc] [0,2,3,1]
+  !   it will return the string 02c322c222c.
+  !
+  function vstring_map ( this , map_old , map_new , nocase ) result ( stringmap )
+    type ( t_vstring ) , intent(inout) :: this
+    type ( t_vstring ) , dimension( : ), intent(in) :: map_old
+    type ( t_vstring ) , dimension( : ), intent(in) :: map_new
+    logical, intent(in), optional :: nocase
+    type(t_vstring) :: stringmap
+    integer :: imap
+    integer :: map_length
+    integer :: map_length_new
+    character ( len = 200) :: message
+    logical :: mapping_done
+    integer :: start
+    integer :: first
+    integer :: last
+    type(t_vstring) :: replaced_string
+    integer :: imap_to_apply
+    logical :: is_map_left_to_apply
+    integer :: map_old_first
+    integer :: map_new_length
+    logical :: nocase_real
+    type(t_vstring) :: stringmap_lower
+    type(t_vstring) :: mapold_lower
+    integer :: status
+    !
+    ! Check input data
+    !
+    call vstring_check_string ( this , "vstring_map" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    map_length = size ( map_old )
+    map_length_new = size ( map_new )
+    if ( map_length /= map_length_new ) then
+       write ( message , * ) "Map for old and new strings are not of the same length. ", &
+            " Length map_old:", map_length , &
+            " Length map_new:", map_length_new , &
+            " in vstring_map"
+       call vstring_error ( this , message , "vstring_map" )
+    endif
+    !
+    ! Process options
+    !
+    if ( present ( nocase ) ) then
+       nocase_real = nocase
+    else
+       nocase_real = .false.
+    endif
+    !
+    ! Check map content
+    !
+    do imap = 1 , map_length
+       call vstring_check_string ( map_old ( imap ) , "vstring_map" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+       call vstring_check_string ( map_new ( imap ) , "vstring_map" , status )
+       if ( status /= VSTRING_ERROR_OK ) then
+          return
+       endif
+    enddo
+    !
+    ! Apply map
+    !
+    start = 1
+    mapping_done = .false.
+    call vstring_new ( stringmap , this )
+    !
+    ! Do a loop over the characters of the string.
+    !
+    do
+       !
+       ! Computes the matches for all maps and
+       ! store the map which is the most at the left of the string.
+       !
+       first = vstring_length ( stringmap ) + 1
+       imap_to_apply = 0
+       is_map_left_to_apply = .false.
+       do imap = 1, map_length
+          if (nocase_real) then
+             stringmap_lower = vstring_tolower ( stringmap )
+             mapold_lower = vstring_tolower ( map_old ( imap ) )
+             map_old_first = vstring_first ( stringmap_lower , mapold_lower , first = start )
+             call vstring_free ( stringmap_lower )
+             call vstring_free ( mapold_lower )
+          else
+             map_old_first = vstring_first ( stringmap , map_old ( imap ) , first = start )
+          endif
+          if ( map_old_first > 0 .AND. map_old_first < first ) then
+             is_map_left_to_apply = .true.
+             imap_to_apply = imap
+             first = map_old_first
+          endif
+       enddo
+       !
+       ! Apply the match which is the left most.
+       !
+       if ( is_map_left_to_apply ) then
+          last = first + vstring_length ( map_old ( imap_to_apply ) ) - 1
+          replaced_string = vstring_replace ( stringmap , first , last ,  map_new ( imap_to_apply ) )
+          call vstring_free ( stringmap )
+          call vstring_new ( stringmap , replaced_string )
+          call vstring_free ( replaced_string )
+          map_new_length = vstring_length ( map_new ( imap_to_apply ) )
+          start = start + map_new_length
+          if ( start > vstring_length ( stringmap ) ) then
+             !
+             ! There are no characters left to map.
+             !
+             mapping_done = .true.
+          endif
+       else
+          mapping_done = .true.
+       endif
+       if ( mapping_done ) then
+          exit
+       endif
+    enddo
+    !
+    ! Cleanup
+    !
+
+  end function vstring_map
+  !
+  ! vstring_replace --
+  !   Removes a range of consecutive characters from string, starting with the character whose
+  !   index is first and ending with the character whose index is last. An index of 1 refers to
+  !   the first character of the string.
+  !   If newstring is specified, then it is placed in the removed character range.
+  !
+  function vstring_replace ( this , first , last , newstring ) result ( stringreplace )
+    type ( t_vstring ) , intent(inout) :: this
+    integer, intent(in) :: first
+    integer, intent(in) :: last
+    type ( t_vstring ) , intent(in), optional :: newstring
+    type(t_vstring) :: stringreplace
+    type(t_vstring) :: part1
+    type(t_vstring) :: part2
+    type(t_vstring) :: newstring_real
+    integer :: length
+    integer :: status
+    call vstring_check_string ( this , "vstring_replace" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_index ( this , first , "vstring_replace" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    call vstring_check_index ( this , last , "vstring_replace" , status )
+    if ( status /= VSTRING_ERROR_OK ) then
+       return
+    endif
+    !
+    ! Get optional arguments
+    !
+    if ( present ( newstring ) ) then
+       call vstring_new ( newstring_real , newstring )
+    else
+       call vstring_new ( newstring_real , "" )
+    endif
+    !
+    ! Compute part #1
+    !
+    if ( first > 1 ) then
+       part1 = vstring_range ( this , 1 , first - 1 )
+    else
+       call vstring_new ( part1 , "" )
+    endif
+    !
+    ! Compute part #2
+    !
+    length = vstring_length ( this )
+    if ( last < length ) then
+       part2 = vstring_range ( this , last + 1 , length )
+    else
+       call vstring_new ( part2 , "" )
+    endif
+    !
+    ! Concatenate the result
+    !
+    call vstring_new ( stringreplace , part1 )
+    call vstring_append ( stringreplace , newstring_real )
+    call vstring_append ( stringreplace , part2 )
+    !
+    ! Cleanup
+    !
+    call vstring_free ( part1 )
+    call vstring_free ( part2 )
+    call vstring_free ( newstring_real )
+  end function vstring_replace
+  !
+  ! TODO :
+  ! vstring_read --
+  !   Returns the vstring which is read on the given unit number,
+  !   or on the standard input if no unit is given.
+  ! Arguments
+  !   unitnumber : the unit number where the string is to read
+  ! Note
+  !   Possible implementation : see get_unit_set_CH
+  !   in iso_varying_string.f90
+  !
+
+  !
+  ! TODO :
+  ! vstring_write --
+  !   Writes the current vstring on the given unit number,
+  !   or on the standard output if no unit is given.
+  ! Arguments
+  !   unitnumber : the unit number where the string is to write
+  !   iostat, optional : the I/O status of the write statement
+  ! Note
+  !   Possible implementation : see put_unit_CH
+  !   in iso_varying_string.f90
+  !    if(PRESENT(iostat)) then
+  !       write(*, FMT='(A,/)', ADVANCE='NO', IOSTAT=iostat) string
+  !    else
+  !       write(*, FMT='(A,/)', ADVANCE='NO') string
+  !    endif
+  !
+
+  !
+  ! TODO :
+  ! vstring_wordend --
+  !   Returns the index of the character just after the last one in the word
+  !   containing character charIndex of string. A word is considered to be any contiguous range of
+  !   alphanumeric (letters or decimal digits) or underscore (connector punctuation)
+  !   characters, or any single character other than these.
+  ! Arguments
+  !   charIndex : the string containing the separator
+  !
+
+  !
+  ! TODO :
+  ! vstring_wordstart --
+  !   Returns the index of the first character in the word containing character charIndex
+  !   of string. charIndex may be specified as for the index method. A word is considered
+  !   to be any contiguous range of alphanumeric (letters or decimal digits) or underscore
+  !   (connector punctuation) characters, or any single character other than these.
+  ! Arguments
+  !   charIndex : the string containing the separator
+  !
+
+
+  !
+  ! vstring_check_index --
+  !   Check that the given index is correct and generates an error if not.
+  !
+  subroutine vstring_check_index ( this , charIndex , origin , status )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    integer, intent(in)         :: charIndex
+    character ( len = * ), intent(in), optional :: origin
+    character ( len = 200 ) :: message
+    integer, intent(out), optional :: status
+    integer :: length
+    integer :: local_status
+    if ( present ( status ) ) then
+       status = VSTRING_ERROR_OK
+    endif
+    call vstring_check_string ( this , "vstring_check_index" , local_status )
+    if ( local_status /= VSTRING_ERROR_OK ) then
+       if ( present ( status ) ) then
+          status = local_status
+       endif
+       return
+    endif
+    length = vstring_length ( this )
+    if ( charIndex < 1 ) then
+       if ( present ( status ) ) then
+          status = VSTRING_ERROR_WRONGINDEX
+       endif
+       write ( message , * ) "Character index ", charIndex , " is less that 1 in vstring_check_index"
+       if ( present ( origin ) ) then
+          call vstring_error ( this , message , origin )
+       else
+          call vstring_error ( this , message )
+       endif
+    elseif ( charIndex > length ) then
+       if ( present ( status ) ) then
+          status = VSTRING_ERROR_WRONGINDEX
+       endif
+       write ( message , * ) "Character index ", charIndex , " is greater that the length ", length , &
+            " in vstring_check_index"
+       if ( present ( origin ) ) then
+          call vstring_error ( this , message , origin )
+       else
+          call vstring_error ( this , message )
+       endif
+    endif
+  end subroutine vstring_check_index
+  !
+  ! vstring_check_string --
+  !   Check that the given string is correct and generates an error if not.
+  !
+  subroutine vstring_check_string ( this , origin , status )
+    type ( t_vstring ) , intent(in) :: this
+    character ( len = 200) :: message
+    character ( len = * ), intent(in), optional :: origin
+    integer, intent(out), optional :: status
+    logical :: stringallocated
+    if ( present ( status ) ) then
+       status = VSTRING_ERROR_OK
+    endif
+    stringallocated = vstring_exists ( this )
+    if ( .NOT.stringallocated ) then
+       if ( present ( status ) ) then
+          status = VSTRING_ERROR_STRINGNOTCREATED
+       endif
+       write ( message , * ) "String is not allocated, size :", size ( this % chars ) , &
+            " in vstring_check_string"
+       if ( present ( origin ) ) then
+          call vstring_error ( this , message , origin )
+       else
+          call vstring_error ( this , message )
+       endif
+    endif
+  end subroutine vstring_check_string
+  !
+  ! vstring_error --
+  !   Generates an error with the given error message
+  !
+  subroutine vstring_error ( this , message , origin )
+    implicit none
+    type ( t_vstring ) , intent(in) :: this
+    character ( len = * ), intent (in) :: message
+    character ( len = * ), intent(in), optional :: origin
+    integer :: length
+    integer, parameter :: length_max = 40
+    logical :: isallocated
+    write ( * , * ) "Internal error in m_vstring"
+    if ( present ( origin ) ) then
+       write ( * , * ) "Origin : ", origin
+    endif
+    length =  vstring_length ( this )
+    isallocated = vstring_exists ( this )
+    if ( isallocated ) then
+       write ( * , * ) "Length:" , length
+       if ( length < length_max ) then
+          write ( * , * ) "Content:", this % chars
+       else
+          write ( * , * ) "Content:", this % chars(1:length_max), "..."
+       endif
+    endif
+#ifdef _VSTRING_ALLOCATABLE
+    write ( * , * ) "Version : allocatable"
+#endif
+#ifdef _VSTRING_POINTER
+    write ( * , * ) "Version : pointer"
+#endif
+    write ( * , * ) "Message :", trim( message )
+    if ( vstring_stoponerror ) then
+       STOP
+    endif
+  end subroutine vstring_error
+  !
+  ! vstring_set_stoponerror --
+  !   Configure the behaviour of the component whenever an
+  !   error is met.
+  !   If stoponerror is true, then the execution stops if an error is encountered.
+  !   If stoponerror is false, then the execution continues if an error is encountered.
+  !   In both cases, a message is displayed on standard output.
+  !
+  subroutine vstring_set_stoponerror ( stoponerror )
+    logical , intent(in) :: stoponerror
+    vstring_stoponerror = stoponerror
+  end subroutine vstring_set_stoponerror
+  !
+  !
+  ! INTERFACE TO STANDARD FORTRAN
+  !
+  ! These methods or routines are simply an interface of standard fortran
+  ! string processing routines.
+  !
+  !
+  ! vstring_iachar --
+  !   Returns the code for the ASCII character in the character position of C.
+  ! Arguments:
+  !   this : the current string
+  !   This is an interface to the standard fortran.
+  ! Example :
+  !   If this is "@", then iachar is 64.
+  !
+  function vstring_iachar ( this ) result ( new_iachar )
+    type ( t_vstring ) , intent(in) :: this
+    integer :: new_iachar
+    integer :: length
+    character ( len = 200 ) :: message
+    character :: thechar
+    length = vstring_length ( this )
+    if ( length/=1 ) then
+       write ( message , * ) "The length of the current string is not 1 :", length , &
+            " in vstring_iachar"
+       call vstring_error ( this , message )
+    endif
+    call vstring_cast ( this , 1 , thechar )
+    new_iachar = iachar ( thechar )
+  end function vstring_iachar
+  !
+  ! vstring_ichar --
+  !   Returns the code for the character in the first character position of
+  !   in the system’s native character set.
+  ! Note
+  !   This is an interface to the standard fortran.
+  ! Arguments:
+  !   this : the current string
+  !
+  function vstring_ichar ( this ) result ( new_ichar )
+    type ( t_vstring ) , intent(in) :: this
+    integer :: new_ichar
+    integer :: length
+    character ( len = 200 ) :: message
+    character :: thechar
+    length = vstring_length ( this )
+    if ( length/=1 ) then
+       write ( message , * ) "The length of the current string is not 1 :", length , &
+            " in vstring_ichar"
+       call vstring_error ( this , message )
+    endif
+    call vstring_cast ( this , 1 , thechar)
+    new_ichar = ichar ( thechar )
+  end function vstring_ichar
+  !
+  ! vstring_charindex --
+  !   Returns the position of the start of the first occurrence of string substring
+  !   as a sub-string in the current string, counting from one. If substring is not present
+  !   in the current string, zero is returned. If the back argument is present and true, the
+  !   return value is the start of the last occurrence rather than the first.
+  ! Note :
+  !   This is a simple interface to the standard fortran intrinsic "index".
+  !
+  function vstring_charindex ( this , substring , back ) result ( charindex )
+    type ( t_vstring ) , intent(in)   :: this
+    type ( t_vstring ) , intent(in)   :: substring
+    logical, intent(in), optional :: back
+    integer :: charindex
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: this_charstring
+    character ( len = VSTRING_BUFFER_SIZE ) :: substring_charstring
+    integer :: this_length
+    integer :: substring_length
+#else
+    character ( len = vstring_length ( this ) ) :: this_charstring
+    character ( len = vstring_length ( substring ) ) :: substring_charstring
+#endif
+    logical :: back_real
+    if ( present ( back ) ) then
+       back_real = back
+    else
+       back_real = .false.
+    endif
+    call vstring_cast ( this , this_charstring )
+    call vstring_cast ( substring , substring_charstring )
+#ifdef _VSTRING_STATIC_BUFFER
+    this_length = vstring_length ( this )
+    substring_length = vstring_length ( substring )
+    charindex = index ( this_charstring(1:this_length) , substring_charstring(1:substring_length) , back_real )
+#else
+    charindex = index ( this_charstring , substring_charstring , back_real )
+#endif
+  end function vstring_charindex
+  !
+  ! vstring_scan --
+  !   Returns the position of a character of the current string that is in set, or zero
+  !   if there is no such character. If the logical back is absent or present with value
+  !   false, the position of the leftmost such character is returned. If back is present
+  !   with value true, the position of the rightmost such character is returned.
+  ! Note :
+  !   This is a simple interface to the standard fortran intrinsic "scan".
+  !
+  function vstring_scan ( this , substring , back ) result ( charindex )
+    type ( t_vstring ) , intent(in)   :: this
+    type ( t_vstring ) , intent(in)   :: substring
+    logical, intent(in), optional :: back
+    integer :: charindex
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: this_charstring
+    character ( len = VSTRING_BUFFER_SIZE ) :: substring_charstring
+    integer :: this_length
+    integer :: substring_length
+#else
+    character ( len = vstring_length ( this ) ) :: this_charstring
+    character ( len = vstring_length ( substring ) ) :: substring_charstring
+#endif
+    logical :: back_real
+    if ( present ( back ) ) then
+       back_real = back
+    else
+       back_real = .false.
+    endif
+    call vstring_cast ( this , this_charstring )
+    call vstring_cast ( substring , substring_charstring )
+#ifdef _VSTRING_STATIC_BUFFER
+    this_length = vstring_length ( this )
+    substring_length = vstring_length ( substring )
+    charindex = scan ( this_charstring(1:this_length) , substring_charstring(1:substring_length) , back_real )
+#else
+    charindex = scan ( this_charstring , substring_charstring , back_real )
+#endif
+  end function vstring_scan
+  !
+  ! vstring_verify --
+  !   Returns the default integer value 0 if each character in the current
+  !   string appears in set, or the position of a character of the current string
+  !   that is not in set. If the logical back is absent or present with value false,
+  !   the position of the left-most such character is returned. If back is
+  !   present with value true, the position of the rightmost such character is returned.
+  ! Note :
+  !   This is a simple interface to the standard fortran intrinsic "verify".
+  !
+  function vstring_verify ( this , substring , back ) result ( charindex )
+    type ( t_vstring ) , intent(in)   :: this
+    type ( t_vstring ) , intent(in)   :: substring
+    logical, intent(in), optional :: back
+    integer :: charindex
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: this_charstring
+    character ( len = VSTRING_BUFFER_SIZE ) :: substring_charstring
+    integer :: this_length
+    integer :: substring_length
+#else
+    character ( len = vstring_length ( this ) ) :: this_charstring
+    character ( len = vstring_length ( substring ) ) :: substring_charstring
+#endif
+    logical :: back_real
+    if ( present ( back ) ) then
+       back_real = back
+    else
+       back_real = .false.
+    endif
+    call vstring_cast ( this , this_charstring )
+    call vstring_cast ( substring , substring_charstring )
+#ifdef _VSTRING_STATIC_BUFFER
+    this_length = vstring_length ( this )
+    substring_length = vstring_length ( substring )
+    charindex = verify ( this_charstring(1:this_length) , substring_charstring(1:substring_length) , back_real )
+#else
+    charindex = verify ( this_charstring , substring_charstring , back_real )
+#endif
+  end function vstring_verify
+  !
+  ! vstring_adjustl --
+  !   Adjusts left to return a string of the same length by removing
+  !   all leading blanks and inserting the same number of trailing blanks.
+  ! Note :
+  !   This is a simple interface to the standard fortran intrinsic "adjustl".
+  !
+  function vstring_adjustl ( this ) result ( newstring )
+    type ( t_vstring ) , intent(in)   :: this
+    type(t_vstring) :: newstring
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: this_charstring
+    character ( len = VSTRING_BUFFER_SIZE ) :: adjusted
+    integer :: this_length
+#else
+    character ( len = vstring_length ( this ) ) :: this_charstring
+    character ( len = vstring_length ( this ) ) :: adjusted
+#endif
+    call vstring_cast ( this , this_charstring )
+    adjusted = adjustl ( this_charstring (:) )
+#ifdef _VSTRING_STATIC_BUFFER
+    this_length = vstring_length ( this )
+    call vstring_new ( newstring , adjusted ( 1 : this_length ) )
+#else
+    call vstring_new ( newstring , adjusted )
+#endif
+  end function vstring_adjustl
+  !
+  ! vstring_adjustr --
+  !   Adjusts right to return a string of the same length by removing
+  !   all trailing blanks and inserting the same number of leading blanks.
+  ! Note :
+  !   This is a simple interface to the standard fortran intrinsic "adjustr".
+  !
+  function vstring_adjustr ( this ) result ( newstring )
+    type ( t_vstring ) , intent(in)   :: this
+    type(t_vstring) :: newstring
+#ifdef _VSTRING_STATIC_BUFFER
+    character ( len = VSTRING_BUFFER_SIZE ) :: this_charstring
+    character ( len = VSTRING_BUFFER_SIZE ) :: adjusted
+    integer :: this_length
+#else
+    character ( len = vstring_length ( this ) ) :: this_charstring
+    character ( len = vstring_length ( this ) ) :: adjusted
+#endif
+    call vstring_cast ( this , this_charstring )
+#ifdef _VSTRING_STATIC_BUFFER
+    this_length = vstring_length ( this )
+    adjusted = adjustr ( this_charstring ( 1 : this_length ) )
+    call vstring_new ( newstring , adjusted ( 1 : this_length ) )
+#else
+    adjusted = adjustr ( this_charstring )
+    call vstring_new ( newstring , adjusted )
+#endif
+  end function vstring_adjustr
+  !
+  ! STATIC METHODS
+  !
+  !
+  ! vstring_achar --
+  !   Static method
+  !   Returns the character located at position I in the ASCII collating sequence.
+  !   This is an interface to the standard fortran.
+  !
+  function vstring_achar ( i ) result ( new_achar )
+    integer, intent (in) :: i
+    character(len=1 ) :: thechar
+    type (t_vstring) :: new_achar
+    thechar = achar(i)
+    call vstring_new ( new_achar , thechar )
+  end function vstring_achar
+  !
+  ! vstring_char --
+  !   Static method
+  !   Returns the character represented by the integer I.
+  !   This is an interface to the standard fortran.
+  ! Example :
+  !   If i is 64, then char is "@".
+  !
+  function vstring_char ( i ) result ( new_achar )
+    integer, intent (in) :: i
+    character(len=1 ) :: thechar
+    type (t_vstring) :: new_achar
+    thechar = char ( i )
+    call vstring_new ( new_achar , thechar )
+  end function vstring_char
+end module m_vstring
+

--- a/src/flibs/src/strings/m_vstringlist.F90
+++ b/src/flibs/src/strings/m_vstringlist.F90
@@ -1491,6 +1491,7 @@ contains
     type ( t_vstringlist ) , intent(inout) :: this
     integer , intent(in) :: icomponent
     integer :: status
+    integer :: length
     character ( len = 500 ) :: message
     type ( t_vstringlist ) :: oldlist
     call vstrlist_checkindex ( this , icomponent , status )
@@ -1502,18 +1503,18 @@ contains
     !
     ! Compute the new length and create the new list.
     !
-    call vstrlist_new ( oldlist , vstrlist_length ( this ) - 1 )
-    if((icomponent > 1) .AND. (icomponent < vstrlist_length (this)))then
+    length = vstrlist_length( this )
+    call vstrlist_new ( oldlist , length - 1 )
+    if((icomponent > 1) .AND. (icomponent < length))then
         oldlist = vstrlist_concat( vstrlist_range ( this, 1, icomponent - 1 ), &
                                  & vstrlist_range ( this, icomponent + 1,      &
-                                 &                  vstrlist_length ( this )))
-    elseif((icomponent == 1) .AND. (vstrlist_length (this) >= 2))then
-        oldlist = vstrlist_range ( this, 2, vstrlist_length ( this ))
-    elseif((icomponent == 1) .AND. (vstrlist_length (this) == 1))then
-        call vstrlist_free ( oldlist )
-        call vstrlist_new ( oldlist )
-    elseif(icomponent == vstrlist_length ( this ))then
-        oldlist = vstrlist_range ( this, 1, vstrlist_length ( this ) - 1)
+                                 &                  length))
+    elseif((icomponent == 1) .AND. (length == 1))then
+        continue
+    elseif((icomponent == 1) .AND. (length >= 2))then
+        oldlist = vstrlist_range ( this, 2, length)
+    elseif(icomponent == length)then
+        oldlist = vstrlist_range ( this, 1, length - 1)
     endif
     call vstrlist_free ( this )
     this = oldlist

--- a/src/flibs/src/strings/m_vstringlist.F90
+++ b/src/flibs/src/strings/m_vstringlist.F90
@@ -1,0 +1,1522 @@
+!
+! m_vstringlist.f90
+!   This module provides OO services to manage lists of 
+!   vstrings.
+!
+!   A list of strings can be created with vstrlist_new and 
+!   several kinds of input arguments. With no additionnal arguments,
+!   the vstrlist_new method creates a list with no items :
+!   
+!      call vstrlist_new ( list )
+!
+!   If one gives one string, the list is created with 1 element.
+!   One can also give an array of strings to the vstrlist_new method.
+!   The list is destroyed with vstrlist_free.
+!   The number of elements in the list can be computed with 
+!   vstrlist_length while vstrlist_exists allows to known 
+!   if a list has been created.
+!
+!   Several methods are provided to acces to the elements of one list 
+!   of strings, for example vstrlist_index, vstrlist_range and vstrlist_set.
+!   The vstrlist_set method allows to set the element at a given index.
+!   The strindex-th item of the list can be accessed with vstrlist_index :
+!
+!     string1 = vstrlist_index ( list , 2 )
+!
+!   The vstrlist_range method returns a new list made of the elements
+!   which index is between two given integers :
+!
+!     list2 = vstrlist_range ( list , 2 , 3 )
+!
+!   To add items to a list, one can use vstrlist_append, vstrlist_concat 
+!   or vstrlist_insert.
+!   The vstrlist_concat and vstrlist_insert methods return a new list 
+!   while vstrlist_append add one item to an existing list (therefore 
+!   increasing the number of elements in the list). In the following 
+!   example, a new list made of 3 items is created :
+!
+!     call vstrlist_new ( list )
+!     call vstrlist_append ( list , "fortran 77" )
+!     call vstrlist_append ( list , "fortran 90" )
+!     call vstrlist_append ( list , "fortran 95" )
+!     call vstrlist_append ( list , "fortran 2003" )
+!     call vstrlist_free ( list )
+!
+!   The vstrlist_split method allows to split a vstring into an list  
+!   of vstrings each time one character is found in a vstring. 
+!   The vstrlist_join method concatenates an list of vstrings,
+!   using a vstring as the join between the components.
+!   In the following example, the string is split at each dot 
+!   and the number of components is 3 :
+!
+!     call vstring_new ( string1 , "comp.lang.fortran" )
+!     strlist = vstrlist_split ( string1 , "." )
+!
+!   One can search for a pattern in a list. The vstrlist_search
+!   returns the index of the found string while vstrlist_lsearch
+!   returns the list of matching strings. These methods 
+!   are based on vstring_match and therefore are powerfull 
+!   tools to process strings.
+!   In the following example, one searches for all fortran
+!   compilers from the 90s (based on the previous sample list):
+!
+!     list2 = vstrlist_search ( list , "fortran 9*" )
+!
+!   Design
+!   This component has been designed with OO principles in mind.
+!   This is why the first argument of every method is named "this",
+!   which is the current object.
+!   If another string is required as a second argument, it may be either 
+!   of type dynamic or as a character(len=*) type, to improve
+!   usability.
+!   This component is meant to evolve following the fortran 2003 standard 
+!   and OO type-bound procedures.
+!
+!   Preprocessing
+!   The following preprocessing macro must be considered :
+!   _VSTRINGLIST_ALLOCATABLE or _VSTRINGLIST_POINTER : see the section 
+!     "Allocatable or pointer" in the documentation of the m_vstring module.
+!
+!   TODO
+!   - Refactor the component and use datastructures/vectors.f90
+! 
+! Copyright (c) 2008 Michael Baudin
+!   
+module m_vstringlist
+  use m_vstring, only : &
+       t_vstring , &
+       vstring_new , &
+       vstring_free , &
+       vstring_set_stoponerror ,&
+       VSTRING_WHITESPACE ,&
+       vstring_length , &
+       vstring_index , &
+       vstring_first , &
+       vstring_append , &
+       VSTRING_SPACE , &
+       vstring_match , &
+       vstring_equals , &
+       vstring_compare , &
+       vstring_cast , &
+       vstring_exists
+  implicit none
+  private
+  !
+  ! Public methods
+  !
+  public :: vstrlist_new
+  public :: vstrlist_free
+  public :: vstrlist_length
+  public :: vstrlist_exists
+  public :: vstrlist_reference_get
+  public :: vstrlist_index
+  public :: vstrlist_append
+  public :: vstrlist_concat
+  public :: vstrlist_insert
+  public :: vstrlist_range
+  public :: vstringlist_set_stoponerror
+  public :: vstrlist_set
+  public :: vstrlist_split
+  public :: vstrlist_join
+  public :: vstrlist_search
+  public :: vstrlist_lsearch
+  public :: vstrlist_sort
+  public :: vstrlist_remove
+  !
+  ! t_vstringlist --
+  !   A list of vstrings is implemented as an array of vstrings.
+  !
+  ! Choose your dynamic string system between _VSTRINGLIST_ALLOCATABLE , _VSTRINGLIST_POINTER
+  ! Allocatable arrays should be used by default.
+  ! But for compatibility of older fortran 90 compilers, pointers are also available.
+  ! These are the recommended settings :
+  ! _VSTRING_POINTER : gfortran, g95
+  ! _VSTRINGLIST_POINTER : Intel Fortran 8.0 (allocatable does not work)
+  !
+  type, public :: t_vstringlist
+     private
+#ifdef _VSTRINGLIST_ALLOCATABLE
+     type ( t_vstring ) , dimension (:), allocatable :: array
+#endif
+#ifdef _VSTRINGLIST_POINTER
+     type ( t_vstring ) , dimension (:), pointer :: array
+#endif
+  end type t_vstringlist
+  !
+  ! vstrlist_new --
+  !   Generic interface for the constructor.
+  !
+  interface vstrlist_new
+     module procedure vstrlist_new_from_empty
+     module procedure vstrlist_new_from_string
+     module procedure vstrlist_new_from_charstring
+     module procedure vstrlist_new_from_array
+     module procedure vstrlist_new_from_list
+     module procedure vstrlist_new_from_integer
+  end interface vstrlist_new
+  !
+  ! vstrlist_append --
+  !   Generic interface to append a string or a list.
+  !
+  interface vstrlist_append
+     module procedure vstrlist_append_string
+     module procedure vstrlist_append_charstring
+     module procedure vstrlist_append_list
+  end interface vstrlist_append
+  !
+  ! vstrlist_concat --
+  !   Generic interface to concatenate a string or a list.
+  !
+  interface vstrlist_concat
+     module procedure vstrlist_concat_string
+     module procedure vstrlist_concat_charstring
+     module procedure vstrlist_concat_list
+  end interface vstrlist_concat
+  !
+  ! vstrlist_insert --
+  !   Generic interface to insert a string into the list.
+  !
+  interface vstrlist_insert
+     module procedure vstrlist_insert_string
+     module procedure vstrlist_insert_charstring
+  end interface vstrlist_insert
+  !
+  ! vstrlist_set --
+  !   Generic interface to set a string in a list.
+  !
+  interface vstrlist_set
+     module procedure vstrlist_set_vstring
+     module procedure vstrlist_set_charstring
+  end interface vstrlist_set
+  !
+  ! vstrlist_split_charstring --
+  !   Generic interface to split a string into a list.
+  !
+  interface vstrlist_split
+     module procedure vstrlist_split_vstring
+     module procedure vstrlist_split_charstring
+  end interface vstrlist_split
+  !
+  ! vstrlist_join --
+  !   Generic interface to join a list into a string.
+  !
+  interface vstrlist_join
+     module procedure vstrlist_join_vstring
+     module procedure vstrlist_join_charstring
+  end interface vstrlist_join
+  !
+  ! vstrlist_search --
+  !   Generic interface to search a string in a list.
+  !
+  interface vstrlist_search
+     module procedure vstrlist_search_vstring
+     module procedure vstrlist_search_charstring
+  end interface vstrlist_search
+  !
+  ! vstrlist_lsearch --
+  !   Generic interface to compute the list of strings which match a pattern.
+  !
+  interface vstrlist_lsearch
+     module procedure vstrlist_lsearch_vstring
+     module procedure vstrlist_lsearch_charstring
+  end interface vstrlist_lsearch
+  !
+  ! vstrlist_sort --
+  !   Generic interface to sort a list of strings
+  !
+  interface vstrlist_sort
+     module procedure vstrlist_sort_basic
+     module procedure vstrlist_sort_command
+  end interface vstrlist_sort
+  !
+  ! Total number of currently available (allocated) lists.
+  ! Note :
+  ! This is mainly for debugging purposes of the vstringlist module itself or client algorithms.
+  ! It allows to check the consistency of vstring_new/vstring_free statements.
+  integer, save :: vstringlist_number_of_lists = 0
+  !
+  ! Set to true to stop whenever an error comes in the vstringlist component.
+  logical, save :: vstringlist_stoponerror = .true.
+  !
+  ! Flags for error management.
+  !
+  integer, parameter :: VSTRINGLIST_ERROR_OK = 0
+  integer, parameter :: VSTRINGLIST_ERROR_WRONG_INDEX = 1
+  integer, parameter :: VSTRINGLIST_ERROR_WRONG_LIST = 2
+  integer, parameter :: VSTRINGLIST_ERROR_WRONG_ITEM = 3
+  !
+  ! Constants
+  !
+  integer, parameter, public :: VSTRINGLIST_INDEX_UNKNOWN = 0
+contains
+  !
+  ! vstrlist_new_from_empty --
+  !   Creates a new empty list of strings, that is, a list with 
+  !   0 strings.
+  !
+  subroutine vstrlist_new_from_empty ( this )
+    type ( t_vstringlist ) , intent(inout) :: this
+    allocate ( this % array ( 0 ) )
+    !
+    ! Update the counter of lists
+    !
+    call vstrlist_reference_add ()
+  end subroutine vstrlist_new_from_empty
+  !
+  ! vstrlist_new_from_string --
+  !   Creates a new string list from one vstring
+  !
+  subroutine vstrlist_new_from_string ( this , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    type ( t_vstring ) , intent(in) :: string
+    allocate ( this % array ( 1 ) )
+    call vstring_new ( this % array ( 1 ) , string )
+    !
+    ! Update the counter of lists
+    !
+    call vstrlist_reference_add ()
+  end subroutine vstrlist_new_from_string
+  !
+  ! vstrlist_new_from_charstring --
+  !   Creates a new string list from one character string
+  !
+  subroutine vstrlist_new_from_charstring ( this , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    character ( len = * ) , intent(in) :: string
+    type ( t_vstring ) :: vstring
+    call vstring_new ( vstring , string )
+    call vstrlist_new_from_string ( this , vstring )
+    call vstring_free ( vstring )
+  end subroutine vstrlist_new_from_charstring
+  !
+  ! vstrlist_new_from_array --
+  !   Creates a new string list from an array of vstrings.
+  !   The number of elements in the new string list is the length of the array.
+  !
+  subroutine vstrlist_new_from_array ( this , array )
+    type ( t_vstringlist ) , intent(inout) :: this
+    type ( t_vstring ) , dimension (:), intent(in) :: array
+    integer :: length
+    integer :: icomponent
+    length = size ( array )
+    allocate ( this % array ( length ) )
+    do icomponent = 1 , length
+       call vstring_new ( this % array ( icomponent ) , array ( icomponent ) )
+    enddo
+    !
+    ! Update the counter of lists
+    !
+    call vstrlist_reference_add ()
+  end subroutine vstrlist_new_from_array
+  !
+  ! vstrlist_new_from_list --
+  !   Creates a new string list with from the existing list of strings "list".
+  !   This implements the copy of a list of strings.
+  !
+  subroutine vstrlist_new_from_list ( this , list )
+    type ( t_vstringlist ) , intent(inout) :: this
+    type ( t_vstringlist ), intent(in) :: list
+    integer :: length
+    integer :: icomponent
+    integer :: status
+    character (len=200) :: message
+    call vstrlist_checklist ( list , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       write ( message , * ) "The given list is not consistent."
+       call vstrlist_error ( this , message )
+       return
+    endif
+    length = vstrlist_length ( list )
+    allocate ( this % array ( length ) )
+    do icomponent = 1 , length
+       call vstring_new ( this % array ( icomponent ) , list % array ( icomponent ) )
+    enddo
+    !
+    ! Update the counter of lists
+    !
+    call vstrlist_reference_add ()
+  end subroutine vstrlist_new_from_list
+  !
+  ! vstrlist_new_from_integer --
+  !   Creates a new string list made of "length" empty strings.
+  !
+  subroutine vstrlist_new_from_integer ( this , length )
+    type ( t_vstringlist ) , intent(inout) :: this
+    integer , intent(in) :: length
+    character ( len = 400 ) :: message
+    integer :: icomponent
+    if ( length < 0 ) then
+       write ( message , * ) "The given length ", length, " is lower than 0."
+       call vstrlist_error ( this , message )
+    endif
+    allocate ( this % array ( length ) )
+    do icomponent = 1 , length
+       call vstring_new ( this % array ( icomponent ) )
+    enddo
+    !
+    ! Update the counter of lists
+    !
+    call vstrlist_reference_add ()
+  end subroutine vstrlist_new_from_integer
+  !
+  ! vstrlist_free --
+  !   Destructor for a list of strings
+  !
+  subroutine vstrlist_free ( this )
+    type ( t_vstringlist ) , intent(inout) :: this
+    integer :: length
+    integer :: icomponent
+    length = vstrlist_length ( this )
+    do icomponent = 1 , length
+       call vstring_free ( this % array ( icomponent ) )
+    enddo
+    deallocate ( this % array )
+    call vstrlist_reference_remove ()
+  end subroutine vstrlist_free
+  !
+  ! vstrlist_reference_add --
+  !   Static method.
+  !   Increase the counter of currently referenced lists.
+  !
+  subroutine vstrlist_reference_add ( )
+    implicit none
+    vstringlist_number_of_lists = vstringlist_number_of_lists + 1
+  end subroutine vstrlist_reference_add
+  !
+  ! vstrlist_reference_remove --
+  !   Static method.
+  !   Decrease the counter of currently referenced lists.
+  !
+  subroutine vstrlist_reference_remove ( )
+    implicit none
+    vstringlist_number_of_lists = vstringlist_number_of_lists - 1
+  end subroutine vstrlist_reference_remove
+  !
+  ! vstrlist_reference_get --
+  !   Static method.
+  !   Returns the number of currently referenced lists.
+  !
+  integer function vstrlist_reference_get ( )
+    implicit none
+    vstrlist_reference_get = vstringlist_number_of_lists
+  end function vstrlist_reference_get
+  !
+  ! vstrlist_length --
+  !   Returns the length, that is, the number of strings, in the current
+  !   list of strings.
+  !
+  integer function vstrlist_length ( this )
+    type ( t_vstringlist ) , intent(in) :: this
+    vstrlist_length = size ( this % array )
+  end function vstrlist_length
+  !
+  ! vstrlist_exists --
+  !   Returns .true. if the string list has allready been created.
+  !
+  logical function vstrlist_exists ( this )
+    type ( t_vstringlist ) , intent(in) :: this
+#ifdef _VSTRINGLIST_ALLOCATABLE
+    vstrlist_exists = allocated ( this % array )
+#endif
+#ifdef _VSTRINGLIST_POINTER
+    vstrlist_exists = associated ( this % array )
+#endif
+  end function vstrlist_exists
+  !
+  ! vstrlist_index --
+  !   Returns a new vstring by getting the vstring at the given index "icomponent" 
+  !   in the list.
+  !   Generates an error if the given index "icomponent" does not exist, that is,
+  !   is lower than 1 or greater than the number of strings in the list.
+  !
+  function vstrlist_index ( this , icomponent ) result ( newstring )
+    type ( t_vstringlist ) , intent(in) :: this
+    integer , intent(in) :: icomponent
+    type ( t_vstring ) :: newstring
+    integer :: status
+    character ( len = 500 ) :: message
+    call vstrlist_checkindex ( this , icomponent , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       write ( message , * ) "Wrong item index #", icomponent, " in current list"
+       call vstrlist_error ( this , message )
+       return
+    endif
+    call vstring_new ( newstring , this % array ( icomponent ) )
+  end function vstrlist_index
+  !
+  ! vstrlist_append_string --
+  !   Add the given vstring at the end of the current list.
+  !
+  subroutine vstrlist_append_string ( this , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    type ( t_vstring ) , intent(in) :: string
+    type ( t_vstringlist ) :: oldlist
+    call vstrlist_new ( oldlist , this )
+    call vstrlist_free ( this )
+    this = vstrlist_concat ( oldlist , string )
+    call vstrlist_free ( oldlist )
+  end subroutine vstrlist_append_string
+  !
+  ! vstrlist_append_charstring --
+  !   Interface to vstrlist_append_string to manage character strings.
+  !
+  subroutine vstrlist_append_charstring ( this , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    character(len=*) , intent(in) :: string
+    type ( t_vstring ) :: vstring
+    call vstring_new ( vstring , string )
+    call vstrlist_append_string ( this , vstring )
+    call vstring_free ( vstring )
+  end subroutine vstrlist_append_charstring
+  !
+  ! vstrlist_append_list --
+  !   Add the given list at the end of the current list.
+  !
+  subroutine vstrlist_append_list ( this , list )
+    type ( t_vstringlist ) , intent(inout) :: this
+    type ( t_vstringlist ) , intent(in) :: list
+    type ( t_vstringlist ) :: oldlist
+    call vstrlist_new ( oldlist , this )
+    call vstrlist_free ( this )
+    this = vstrlist_concat ( oldlist , list )
+    call vstrlist_free ( oldlist )
+  end subroutine vstrlist_append_list
+  !
+  ! vstrlist_concat_string --
+  !   Returns a new list by concatenating the current list to the given string.
+  ! Arguments
+  !   string : the string to be concatenated
+  !   newlist : the concatenated list
+  !
+  function vstrlist_concat_string ( this , string ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: string
+    type ( t_vstringlist ) :: newlist
+    ! Local variables
+    integer :: newlength
+    integer :: oldlength
+    integer :: icomponent
+    !
+    ! Compute the new length and create the new list.
+    !
+    oldlength = vstrlist_length ( this )
+    newlength = oldlength + 1
+    call vstrlist_new ( newlist , newlength )
+    !
+    ! Fill the new list
+    !
+    do icomponent = 1 , oldlength
+       call vstring_free ( newlist % array ( icomponent ) )
+       call vstring_new ( newlist % array ( icomponent )  , this % array ( icomponent ) )
+    enddo
+    call vstring_free ( newlist % array ( newlength ) )
+    call vstring_new ( newlist % array ( newlength )  , string )
+  end function vstrlist_concat_string
+  !
+  ! vstrlist_concat_charstring --
+  !   Interface to vstrlist_concat_string to manage character strings.
+  !
+  function vstrlist_concat_charstring ( this , string ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    character (len=*), intent(in) :: string
+    type ( t_vstringlist ) :: newlist
+    type ( t_vstring ) :: vstring
+    call vstring_new ( vstring , string )
+    newlist = vstrlist_concat_string ( this , vstring )
+    call vstring_free ( vstring )
+  end function vstrlist_concat_charstring
+  !
+  ! vstrlist_concat_list --
+  !   Returns a new list by concatenating the current list to the given list.
+  ! Arguments
+  !   list : the list to be concatenated
+  !   newlist : the concatenated list
+  !
+  function vstrlist_concat_list ( this , list ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    type ( t_vstringlist ) , intent(in) :: list
+    type ( t_vstringlist ) :: newlist
+    ! Local variables
+    integer :: newlength
+    integer :: oldlength
+    integer :: listlength
+    integer :: icomponent
+    integer :: icomponent_reduced
+    !
+    ! Compute the new length and create the new list.
+    !
+    oldlength = vstrlist_length ( this )
+    listlength = vstrlist_length ( list )
+    newlength = oldlength + listlength
+    call vstrlist_new ( newlist , newlength )
+    !
+    ! Fill the new list
+    !
+    do icomponent = 1 , oldlength
+       call vstring_free ( newlist % array ( icomponent ) )
+       call vstring_new ( newlist % array ( icomponent )  , this % array ( icomponent ) )
+    enddo
+    do icomponent = oldlength + 1 , newlength
+       icomponent_reduced = icomponent - oldlength
+       call vstring_free ( newlist % array ( icomponent ) )
+       call vstring_new ( newlist % array ( icomponent )  , list % array ( icomponent_reduced ) )
+    enddo
+  end function vstrlist_concat_list
+  !
+  ! vstrlist_insert_string --
+  !   Creates a new list by inserting the given string into the current list just 
+  !   before the given index "strindex".
+  ! Arguments
+  !   string : the string to be insert
+  !   strindex : the index where the string must be inserted
+  !   newlist : the new list
+  !
+  function vstrlist_insert_string ( this , strindex, string ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    type ( t_vstring ) , intent(in) :: string
+    integer , intent (in) :: strindex
+    type ( t_vstringlist ) :: newlist
+    ! Local variables
+    integer :: newlength
+    integer :: oldlength
+    integer :: icomponent
+    integer :: icomponent_reduced
+    integer :: status
+    oldlength = vstrlist_length ( this )
+    if ( oldlength == 0 .AND. strindex == 1 ) then
+       ! No problem : we try to insert a string at the begining of an empty list
+    else
+       !
+       ! Check the index
+       !
+       call vstrlist_checkindex ( this , strindex , status )
+       if ( status /= VSTRINGLIST_ERROR_OK ) then
+          return
+       endif
+    endif
+    !
+    ! Compute the new length and create the new list.
+    !
+    newlength = oldlength + 1
+    call vstrlist_new ( newlist , newlength )
+    !
+    ! Fill the new list
+    !
+    do icomponent = 1 , strindex - 1
+       call vstring_free ( newlist % array ( icomponent ) )
+       call vstring_new ( newlist % array ( icomponent )  , this % array ( icomponent ) )
+    enddo
+    call vstring_free ( newlist % array ( strindex ) )
+    call vstring_new ( newlist % array ( strindex )  , string )
+    do icomponent = strindex + 1 , newlength
+       icomponent_reduced = icomponent - 1
+       call vstring_free ( newlist % array ( icomponent ) )
+       call vstring_new ( newlist % array ( icomponent )  , this % array ( icomponent_reduced ) )
+    enddo
+  end function vstrlist_insert_string
+  !
+  ! vstrlist_insert_charstring --
+  !   Interface to vstrlist_insert_string to manage character strings.
+  !
+  function vstrlist_insert_charstring ( this , strindex , string ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    character (len=*), intent(in) :: string
+    integer , intent(in) :: strindex
+    type ( t_vstringlist ) :: newlist
+    type ( t_vstring ) :: vstring
+    call vstring_new ( vstring , string )
+    newlist = vstrlist_insert_string ( this , strindex , vstring )
+    call vstring_free ( vstring )
+  end function vstrlist_insert_charstring
+  !
+  ! vstrlist_range --
+  !   Returns a new list by extracting items of index  
+  !   from first and last (included).
+  ! Arguments
+  !   first : the index of the first element to include
+  !   last : the index of the last element to include
+  !
+  function vstrlist_range ( this , first , last ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    integer , intent(in) :: first
+    integer , intent(in) :: last
+    type ( t_vstringlist ) :: newlist
+    integer :: icomponent
+    character (len= 500 ) :: message
+    integer :: status
+    !
+    ! Check indices.
+    !
+    call vstrlist_checkindex ( this , first , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       write ( message , * ) "Wrong index first : ", first , " in vstrlist_range"
+       call vstrlist_error ( this , message )
+       return
+    endif
+    call vstrlist_checkindex ( this , last , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       write ( message , * ) "Wrong index last : ", last , " in vstrlist_range"
+       call vstrlist_error ( this , message )
+       return
+    endif
+    !
+    ! Compute new list
+    !
+    call vstrlist_new ( newlist )
+    do icomponent = first , last
+       call vstrlist_append ( newlist , this % array ( icomponent ) )
+    enddo
+  end function vstrlist_range
+  !
+  ! vstrlist_set_vstring --
+  !   Set the vstring "string" at the given "strindex" in the list,
+  !   replacing the existing vstring by the new one.
+  ! Arguments
+  !   strindex : the index where to put the new string
+  !   string : the new string
+  !
+  subroutine vstrlist_set_vstring ( this , strindex , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    integer , intent(in) :: strindex
+    type ( t_vstring ) , intent(in) :: string
+    integer :: status
+    call vstrlist_checkindex ( this , strindex , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       return
+    endif
+    call vstring_free ( this % array ( strindex ) )
+    call vstring_new ( this % array ( strindex ) , string )
+  end subroutine vstrlist_set_vstring
+  !
+  ! vstrlist_set_charstring --
+  !   Set the character(len=*) "string" at the given "strindex" in the list,
+  !   replacing the existing vstring by the new one.
+  !
+  subroutine vstrlist_set_charstring ( this , strindex , string )
+    type ( t_vstringlist ) , intent(inout) :: this
+    integer , intent(in) :: strindex
+    character(len=*) , intent(in) :: string
+    type ( t_vstring ) :: newvstring
+    call vstring_new ( newvstring , string )
+    call vstrlist_set_vstring ( this , strindex , newvstring )
+    call vstring_free ( newvstring )
+  end subroutine vstrlist_set_charstring
+  !
+  ! vstrlist_split_vstring --
+  !   Returns an list of vstrings whose elements are the components in the current string.
+  !   Returns a list of vstrings created by splitting string at each character that is in 
+  !   the splitChars argument. Each element of the result array will consist of 
+  !   the characters from string that lie between instances of the characters in 
+  !   splitChars. The number of components is zero if string contains adjacent 
+  !   characters in splitChars. If splitChars is an empty string then each character of string 
+  !   becomes a separate element of the result list. SplitChars defaults to the 
+  !   standard white-space characters (space, newline, carriage return and tab).
+  ! Arguments:
+  !   this   The current string to process
+  !   splitChars The string containing the characters where to split
+  !
+  function vstrlist_split_vstring ( this , splitChars ) result ( newlist )
+    implicit none
+    type ( t_vstring ), intent(in) :: this
+    type ( t_vstring ), intent(in), optional :: splitChars
+    type ( t_vstringlist ) :: newlist
+    ! Local variables
+    integer :: firstsplitchar
+    type ( t_vstring ) :: splitChars_real
+    type ( t_vstring ) :: component
+    integer :: splitChars_real_length
+    integer :: this_length
+    integer :: icharacter
+    type ( t_vstring ) :: current_char
+    integer :: component_length
+    !
+    ! Process options
+    !
+    if ( present ( splitChars ) ) then
+       call vstring_new ( splitChars_real , splitChars )
+    else
+       call vstring_new ( splitChars_real , VSTRING_WHITESPACE )
+    endif
+    !
+    ! Initialization
+    !
+    splitChars_real_length = vstring_length ( splitChars_real )
+    this_length = vstring_length ( this )
+    !
+    ! Process the special case where the splitchars is empty
+    !
+    if ( splitChars_real_length == 0 ) then
+       !
+       ! There are no characters in the string to split.
+       ! Split at every character.
+       !
+       call vstrlist_new ( newlist )
+       do icharacter = 1 , this_length
+          component = vstring_index ( this , icharacter )
+          call vstrlist_append ( newlist , component )
+          call vstring_free ( component )
+       enddo
+    else
+       call vstrlist_new ( newlist )
+       call vstring_new ( component , "" )
+       !
+       ! Loop over the characters of the current string.
+       !
+       do icharacter = 1 , this_length
+          current_char = vstring_index ( this , icharacter )
+          firstsplitchar = vstring_first ( splitChars_real , current_char )
+          if ( firstsplitchar /= 0 ) then
+             !
+             ! Current character is a separator
+             !
+             call vstrlist_append ( newlist , component )
+             call vstring_free ( component )
+             call vstring_new ( component , "" )
+          else
+             call vstring_append ( component , current_char )
+          endif
+          call vstring_free ( current_char )
+       enddo
+       ! Store the last component
+       component_length = vstring_length ( component )
+       if ( component_length > 0 ) then
+          call vstrlist_append ( newlist , component )
+       endif
+       call vstring_free ( component )
+    endif
+    !
+    ! Clean-up
+    !
+    call vstring_free ( splitChars_real )
+  end function vstrlist_split_vstring
+  !
+  ! vstrlist_split_vstring --
+  !   Same as previous but with character(len=*) [arg splitChars].
+  !
+  function vstrlist_split_charstring ( this , splitChars ) result ( newlist )
+    implicit none
+    type ( t_vstring ), intent(in) :: this
+    character(len=*), intent(in) :: splitChars
+    type ( t_vstringlist ) :: newlist
+    type ( t_vstring ) :: vsplitChars
+    call vstring_new ( vsplitChars , splitChars )
+    newlist = vstrlist_split_vstring ( this , vsplitChars )
+    call vstring_free ( vsplitChars )
+  end function vstrlist_split_charstring
+  !
+  ! vstrlist_join_vstring --
+  !   Returns the string formed by joining all 
+  !   of the elements of list together with joinString separating 
+  !   each adjacent pair of elements. 
+  !   The joinString argument defaults to a space character.
+  ! Arguments:
+  !   this : the list of vstrings
+  !   joinString : the string which is used to join the elements
+  !
+  function vstrlist_join_vstring ( this , joinString ) result ( newstring )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    type ( t_vstring ), intent(in), optional :: joinString
+    type ( t_vstring ) :: newstring
+    integer :: numberOfComponents
+    type ( t_vstring ) :: joinString_real
+    integer :: icomponent
+    !
+    ! Process options
+    !
+    if ( present ( joinString ) ) then
+       call vstring_new ( joinString_real , joinString )
+    else
+       call vstring_new ( joinString_real , VSTRING_SPACE )
+    endif
+    !
+    ! Initialize
+    !
+    numberOfComponents = vstrlist_length ( this )
+    call vstring_new ( newstring )
+    if ( numberOfComponents > 0 ) then
+       !
+       ! Join the elements
+       !
+       do icomponent = 1 , numberOfComponents - 1
+          call vstring_append ( newstring , this % array ( icomponent ) )
+          call vstring_append ( newstring , joinString_real )
+       enddo
+       !
+       ! Last but not the least
+       !
+       call vstring_append ( newstring , this % array ( numberOfComponents ) )
+    endif
+    !
+    ! Clean-up
+    !
+    call vstring_free ( joinString_real )
+  end function vstrlist_join_vstring
+  !
+  ! vstrlist_join_charstring --
+  !   Same as previous but with character(len=*) joinString.
+  !
+  function vstrlist_join_charstring ( this , joinString ) result ( newstring )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    character(len=*), intent(in) :: joinString
+    type ( t_vstring ) :: newstring
+    type ( t_vstring ) :: joinVString
+    call vstring_new ( joinVString , joinString )
+    newstring = vstrlist_join_vstring ( this , joinVString )
+    call vstring_free ( joinVString )
+  end function vstrlist_join_charstring
+  !
+  ! vstrlist_search_vstring --
+  !   This command searches the elements of list to see if one of them matches 
+  !   pattern. If so, the command returns the index of the first matching element.
+  !   If not, the command returns 0.
+  ! Arguments
+  !   pattern : the pattern against which the items of the list are compared.
+  !   first : If the optional argument "first" is provided, then the list is searched 
+  !     starting at position first.
+  !     Default value of first is 1
+  !   notmatch : If the optional argument "notmatch" is provided, this negates the sense 
+  !     of the match, returning the index of the first non-matching value in the list.
+  !     Default value of notmatch is .false.
+  !   exact : Set to true so that the list element must contain exactly the same string as pattern.
+  !     Default value of exact is .false.
+  ! TODO :
+  !    -ascii
+  !    -decreasing
+  !    -dictionary
+  !    -exact
+  !    -glob
+  !    -increasing
+  !    -inline
+  !    -integer
+  !    -real
+  !    -regexp : yes yes yes !!!
+  !    -sorted
+  !
+  function vstrlist_search_vstring ( this , pattern , first , notmatch , &
+       exact ) result ( strindex )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    type ( t_vstring ) , intent(in) :: pattern
+    integer , intent(in), optional :: first
+    logical , intent(in), optional :: notmatch
+    logical , intent(in), optional :: exact
+    integer :: strindex
+    integer :: length
+    integer :: icomponent
+    logical :: match
+    integer :: first_real
+    logical :: notmatch_real
+    logical :: exact_real
+    !
+    ! Process options
+    !
+    if ( present ( first ) ) then
+       first_real = first
+    else
+       first_real = 1
+    endif
+    if ( present ( notmatch ) ) then
+       notmatch_real = notmatch
+    else
+       notmatch_real = .false.
+    endif
+    if ( present ( exact ) ) then
+       exact_real = exact
+    else
+       exact_real = .false.
+    endif
+    length = vstrlist_length ( this )
+    !
+    ! By default, no item matches
+    !
+    strindex = VSTRINGLIST_INDEX_UNKNOWN
+    !
+    ! Now search the item
+    !
+    do icomponent = first_real , length
+       if ( exact_real ) then
+          match = vstring_equals ( this % array ( icomponent ) , pattern )
+       else
+          match = vstring_match ( this % array ( icomponent ) , pattern )
+       endif
+       if ( notmatch_real ) then
+          if ( .NOT. match ) then
+             strindex = icomponent
+             exit
+          endif
+       else
+          if ( match ) then
+             strindex = icomponent
+             exit
+          endif
+       endif
+    enddo
+  end function vstrlist_search_vstring
+  !
+  ! vstrlist_search_charstring --
+  !   Same as previous with character (len=*) "pattern".
+  !
+  function vstrlist_search_charstring ( this , pattern , first , notmatch , &
+       exact ) result ( strindex )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    character ( len = * ) , intent(in) :: pattern
+    integer , intent(in), optional :: first
+    logical , intent(in), optional :: notmatch
+    logical , intent(in), optional :: exact
+    integer :: strindex
+    type ( t_vstring ) :: vpattern
+    call vstring_new ( vpattern , pattern )
+    strindex = vstrlist_search_vstring ( this , vpattern , first , notmatch , exact )
+    call vstring_free ( vpattern )
+  end function vstrlist_search_charstring
+  !
+  ! vstrlist_lsearch_vstring --
+  !   This command searches the elements of list to see if one of them matches 
+  !   pattern. If so, the command returns the list of the first matching element.
+  !   If not, the command returns an empty list.
+  ! Arguments
+  !   pattern : the pattern against which the items of the list are compared.
+  !   first : If the optional argument "first" is provided, then the list is searched 
+  !     starting at position first.
+  !   notmatch : If the optional argument "notmatch" is provided, this negates the sense 
+  !     of the match, returning the index of the first non-matching value in the list.
+  !   exact : The list element must contain exactly the same string as pattern.
+  !   allitems : If provided and true, returns the list of all matching elements.
+  !      Default value of "allitems" is .false.
+  ! TODO :
+  !    -ascii
+  !    -decreasing
+  !    -dictionary
+  !    -exact
+  !    -glob
+  !    -increasing
+  !    -inline
+  !    -integer
+  !    -real
+  !    -sorted
+  !
+  function vstrlist_lsearch_vstring ( this , pattern , first , notmatch , &
+       exact , allitems ) result ( newlist )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    type ( t_vstring ) , intent(in) :: pattern
+    integer , intent(in), optional :: first
+    logical , intent(in), optional :: notmatch
+    logical , intent(in), optional :: exact
+    logical , intent(in), optional :: allitems
+    type ( t_vstringlist ) :: newlist
+    integer :: strindex
+    integer :: strindex_current
+    logical :: done
+    logical :: allitems_real
+    !
+    ! Process options
+    !
+    if ( present ( allitems ) ) then
+       allitems_real = allitems
+    else
+       allitems_real = .false.
+    endif
+    !
+    ! Initialize
+    !
+    if ( present ( first ) ) then
+       strindex_current = first
+    else
+       strindex_current = 1
+    endif
+    done = .false.
+    call vstrlist_new ( newlist )
+    !
+    ! Search until no element match
+    !
+    do while ( .NOT. done )
+       strindex = vstrlist_search_vstring ( this , pattern , strindex_current , notmatch , &
+            exact )
+       if ( strindex == VSTRINGLIST_INDEX_UNKNOWN ) then
+          done = .true.
+       else
+          call vstrlist_append ( newlist , this % array ( strindex ) )
+       endif
+       ! Update the first element to look at
+       strindex_current = strindex + 1
+       if ( .NOT. allitems_real ) then
+          done = .true.
+       endif
+    enddo
+  end function vstrlist_lsearch_vstring
+  !
+  ! vstrlist_lsearch_charstring --
+  !   Same as previous with character(len=*) "pattern".
+  !
+  function vstrlist_lsearch_charstring ( this , pattern , first , notmatch , &
+       exact , allitems ) result ( newlist )
+    implicit none
+    type ( t_vstringlist ), intent(in) :: this
+    character ( len = * ) , intent(in) :: pattern
+    integer , intent(in), optional :: first
+    logical , intent(in), optional :: notmatch
+    logical , intent(in), optional :: exact
+    logical , intent(in), optional :: allitems
+    type ( t_vstringlist ) :: newlist
+    type ( t_vstring) :: vpattern
+    call vstring_new ( vpattern , pattern )
+    newlist = vstrlist_lsearch_vstring ( this , vpattern , first , notmatch , &
+         exact , allitems )
+    call vstring_free ( vpattern )
+  end function vstrlist_lsearch_charstring
+  !
+  ! Include template sorting methods 
+  !
+#define _QSORTARRAY_TYPE t_vstring
+#define _QSORTARRAY_MODULE m_vstring
+#include "qsortarray_template.F90"
+  !
+  ! vstrlist_sort_basic --
+  !   This command sorts the elements of list and returns a new list in sorted order.
+  ! Arguments
+  !   increasing, optional : If provided and true or not provided, sort the list in increasing order 
+  !     (``smallest'' items first).
+  !     If provided and false, sort the list in decreasing order (``largest'' items first).
+  !     Default value of "increasing" is true.
+  !   classtype, optional : 
+  !     If provided, converts the items of the list into that class of data before comparing 
+  !     the items. The possible values of classtype are :
+  !       "ascii" : compare items as strings ( default )
+  !       "integer" : convert strings into integer before comparing items
+  !       "real" : convert strings into real before comparing items
+  !       "dictionnary" : Use dictionary-style comparison. 
+  !          This is the same as "ascii" except case is ignored.
+  !      If classtype is not provided, it defaults to "ascii".
+  !   unique, optional :: if provided and true, then only the last set of duplicate 
+  !     elements found in the list will be retained. Note that duplicates are 
+  !     determined relative to the comparison used in the sort.
+  !     Two items are considered the same if the comparison command returns 0.
+  !
+  function vstrlist_sort_basic ( this , increasing , classtype , unique ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    logical , intent(in), optional :: increasing
+    character(len=*) , intent(in), optional :: classtype
+    logical , intent(in), optional :: unique
+    type ( t_vstringlist ) :: newlist
+    logical :: increasing_real
+    character(len=200) :: classtype_real
+    character ( len = 200 ) :: message
+    logical :: unique_real
+    !
+    ! Process options
+    !
+    if ( present ( increasing ) ) then
+       increasing_real = increasing
+    else
+       increasing_real = .true.
+    endif
+    if ( present ( classtype ) ) then
+       classtype_real = classtype
+    else
+       classtype_real = "ascii"
+    endif
+    if ( present ( unique ) ) then
+       unique_real = unique
+    else
+       unique_real = .false.
+    endif
+    !
+    ! Create and sort the list
+    !
+    call vstrlist_new ( newlist , this )
+    select case ( classtype_real )
+    case ( "ascii" )
+       if ( increasing_real ) then
+          call qsort_array ( newlist % array , vstrlist_compare_asciiincreasing )
+       else
+          call qsort_array ( newlist % array , vstrlist_compare_asciidecreasing )
+       endif
+    case ( "dictionnary" )
+       if ( increasing_real ) then
+          call qsort_array ( newlist % array , vstrlist_compare_dictincreasing )
+       else
+          call qsort_array ( newlist % array , vstrlist_compare_dictdecreasing )
+       endif
+    case ( "integer" )
+       if ( increasing_real ) then
+          call qsort_array ( newlist % array , vstrlist_compare_integerincreasing )
+       else
+          call qsort_array ( newlist % array , vstrlist_compare_integerdecreasing )
+       endif
+    case ( "real" )
+       if ( increasing_real ) then
+          call qsort_array ( newlist % array , vstrlist_compare_realincreasing )
+       else
+          call qsort_array ( newlist % array , vstrlist_compare_realdecreasing )
+       endif
+    case default
+       write ( message , * )  "Unknown class type :", trim(classtype)
+       call vstrlist_error ( this , message )
+    end select
+    !
+    ! Eliminate duplicate entries
+    !
+    if ( unique_real ) then
+       select case ( classtype_real )
+       case ( "ascii" )
+          call vstrlist_eliminateduplicate ( newlist , vstrlist_compare_asciiincreasing )
+       case ( "dictionnary" )
+          call vstrlist_eliminateduplicate ( newlist , vstrlist_compare_dictincreasing )
+       case ( "integer" )
+          call vstrlist_eliminateduplicate ( newlist , vstrlist_compare_integerincreasing )
+       case ( "real" )
+          call vstrlist_eliminateduplicate ( newlist , vstrlist_compare_realincreasing )
+       case default
+          write ( message , * )  "Unknown class type :", trim(classtype)
+          call vstrlist_error ( this , message )
+       end select
+    endif
+  end function vstrlist_sort_basic
+  !
+  ! vstrlist_sort_command --
+  !   This command sorts the elements of list and returns a new list in sorted order.
+  ! Arguments
+  !   command : use that function as a comparison function.
+  !     The command is expected to return -1, 0, or 1, depending on whether 
+  !     string_a is lexicographically less than, equal to, or greater than string_b.
+  !   unique, optional :: if provided and true, then only the last set of duplicate 
+  !     elements found in the list will be retained. Note that duplicates are 
+  !     determined relative to the comparison used in the sort.
+  !     Two items are considered the same if the comparison command returns 0.
+  !
+  function vstrlist_sort_command ( this , command , unique ) result ( newlist )
+    type ( t_vstringlist ) , intent(in) :: this
+    logical, optional , intent(in) :: unique
+    interface
+       integer function command ( string_a , string_b )
+         use m_vstring, only : t_vstring
+         type(t_vstring), intent(in) :: string_a
+         type(t_vstring), intent(in) :: string_b
+       end function command 
+    end interface
+    type ( t_vstringlist ) :: newlist
+    logical :: unique_real
+    if ( present ( unique ) ) then
+       unique_real = unique
+    else
+       unique_real = .false.
+    endif
+    call vstrlist_new ( newlist , this )
+    call qsort_array ( newlist % array , command )
+    if ( unique_real ) then
+       call vstrlist_eliminateduplicate ( newlist , command )
+    endif
+  end function vstrlist_sort_command
+  !
+  ! vstrlist_compare_asciiincreasing --
+  !   Comparing function as a support for sorting a list of strings
+  !   in increasing order.
+  !   A simple interface to vstring_compare.
+  !
+  function vstrlist_compare_asciiincreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstring_compare ( string_a , string_b )
+  end function vstrlist_compare_asciiincreasing
+  !
+  ! vstrlist_compare_asciidecreasing --
+  !   Comparing function as a support for sorting a list of strings
+  !   in decreasing order.
+  !
+  function vstrlist_compare_asciidecreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstring_compare ( string_a , string_b )
+    ! Decreasing :
+    compare = - compare
+  end function vstrlist_compare_asciidecreasing
+  !
+  ! vstrlist_compare_dictincreasing --
+  !   Compare two string in the style of the dictionnary.
+  !   A simple interface to vstring_compare with no case.
+  !
+  function vstrlist_compare_dictincreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstring_compare ( string_a , string_b , nocase = .true. )
+  end function vstrlist_compare_dictincreasing
+  !
+  ! vstrlist_compare_dictdecreasing --
+  !   Compare two string in the style of the dictionnary 
+  !   in decreasing order.
+  !
+  function vstrlist_compare_dictdecreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstrlist_compare_dictincreasing ( string_a , string_b )
+    ! Decreasing :
+    compare = - compare
+  end function vstrlist_compare_dictdecreasing
+  !
+  ! vstrlist_compare_integerincreasing --
+  !   Comparing function to compare two integers and sort the list of strings
+  !   in increasing order.
+  !
+  function vstrlist_compare_integerincreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: value_a
+    integer :: value_b
+    integer :: compare
+    call vstring_cast ( string_a , value_a )
+    call vstring_cast ( string_b , value_b )
+    if ( value_a < value_b ) then
+       compare = -1
+    elseif ( value_a == value_b ) then
+       compare = 0
+    else
+       compare = 1
+    endif
+  end function vstrlist_compare_integerincreasing
+  !
+  ! vstrlist_compare_integerdecreasing --
+  !   Comparing function to compare two integers and sort the list of strings
+  !   in decreasing order.
+  !
+  function vstrlist_compare_integerdecreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstrlist_compare_integerincreasing ( string_a , string_b )
+    compare = - compare
+  end function vstrlist_compare_integerdecreasing
+  !
+  ! vstrlist_compare_realincreasing --
+  !   Comparing function to compare two integers and sort the list of strings
+  !   in increasing order.
+  !
+  function vstrlist_compare_realincreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    real :: value_a
+    real :: value_b
+    integer :: compare
+    call vstring_cast ( string_a , value_a )
+    call vstring_cast ( string_b , value_b )
+    if ( value_a < value_b ) then
+       compare = -1
+    elseif ( value_a == value_b ) then
+       compare = 0
+    else
+       compare = 1
+    endif
+  end function vstrlist_compare_realincreasing
+  !
+  ! vstrlist_compare_realdecreasing --
+  !   Comparing function to compare two integers and sort the list of strings
+  !   in decreasing order.
+  !
+  function vstrlist_compare_realdecreasing ( string_a , string_b ) result ( compare )
+    type(t_vstring), intent(in) :: string_a
+    type(t_vstring), intent(in) :: string_b
+    integer :: compare
+    compare = vstrlist_compare_realincreasing ( string_a , string_b )
+    compare = - compare
+  end function vstrlist_compare_realdecreasing
+  !
+  ! vstrlist_eliminateduplicate --
+  !   Eliminate duplicate entries in the current sorted list of strings, 
+  !   using the given comparison command, which must returns 0 
+  !   if the two strings are equal.
+  !
+  subroutine vstrlist_eliminateduplicate ( this , command )
+    type ( t_vstringlist ) , intent(inout) :: this
+    interface
+       integer function command ( string_a , string_b )
+         use m_vstring, only : t_vstring
+         type(t_vstring), intent(in) :: string_a
+         type(t_vstring), intent(in) :: string_b
+       end function command 
+    end interface
+    type ( t_vstringlist )  :: newlist
+    integer :: length
+    integer :: icomponent
+    integer :: compare
+    integer :: newlength
+    !
+    ! Create an empty list
+    !
+    call vstrlist_new ( newlist )
+    !
+    ! Create the newlist with the first item of the list as the only element, if any
+    !
+    length = vstrlist_length ( this )
+    if ( length > 0 ) then
+       call vstrlist_append ( newlist , this % array ( 1 ) )
+    endif
+    !
+    ! Add items only if they are different.
+    !
+    do icomponent = 2 , length
+       compare = command ( this % array ( icomponent - 1 ) , this % array ( icomponent ) )
+       if ( compare /= 0 ) then
+          call vstrlist_append ( newlist , this % array ( icomponent ) )
+       endif
+    enddo
+    !
+    ! Replace the current list by the newlist, if necessary
+    !
+    newlength = vstrlist_length ( newlist )
+    if ( newlength /= length ) then
+       call vstrlist_free ( this )
+       call vstrlist_new ( this , newlist )
+    endif
+  end subroutine vstrlist_eliminateduplicate
+  !
+  ! vstrlist_checkindex --
+  !   Check that the given integer index exist in the current list.
+  !   Generates an error if not.
+  !   If no error occurs, set the status to azero value.
+  !   If an error occurs, set the status to a non-zero value.
+  !
+  subroutine vstrlist_checkindex ( this , icomponent , status )
+    type ( t_vstringlist ) , intent(in) :: this
+    integer, intent(in) :: icomponent
+    integer , intent(out) :: status
+    integer :: length
+    character ( len = 400 ) :: message
+    status = VSTRINGLIST_ERROR_OK
+    if ( icomponent < 1 ) then
+       status = VSTRINGLIST_ERROR_WRONG_INDEX
+       write ( message , * ) "The given index ", icomponent , " is lower than 1."
+       call vstrlist_error ( this , message )
+    endif
+    length = vstrlist_length ( this )
+    if ( icomponent > length ) then
+       status = VSTRINGLIST_ERROR_WRONG_INDEX
+       write ( message , * ) "The given index ", icomponent , &
+            " is greater than the length of the list : ", length
+       call vstrlist_error ( this , message )
+    endif
+  end subroutine vstrlist_checkindex
+  !
+  ! vstrlist_checklist --
+  !   Check that the given list exists.
+  !   Generates an error if not.
+  !   If no error occurs, set the status to azero value.
+  !   If an error occurs, set the status to a non-zero value.
+  !
+  subroutine vstrlist_checklist ( this , status )
+    type ( t_vstringlist ) , intent(in) :: this
+    integer , intent(out) :: status
+    integer :: length
+    character ( len = 400 ) :: message
+    integer :: icomponent
+    logical :: listexists
+    logical :: stringexists
+    status = VSTRINGLIST_ERROR_OK
+    listexists = vstrlist_exists ( this )
+    if ( .NOT. listexists ) then
+       status = VSTRINGLIST_ERROR_WRONG_LIST
+       write ( message , * ) "The list does not exist."
+       call vstrlist_error ( this , message )
+    endif
+    if ( listexists ) then
+       length = vstrlist_length ( this )
+       !
+       ! Check each string
+       !
+       do icomponent = 1 , length
+          stringexists = vstring_exists ( this % array ( icomponent ) )
+          if ( .NOT. stringexists ) then
+             status = VSTRINGLIST_ERROR_WRONG_ITEM
+             write ( message , * ) "The item #", icomponent , " does not exist."
+             call vstrlist_error ( this , message )
+             exit
+          endif
+       enddo
+    endif
+  end subroutine vstrlist_checklist
+  !
+  ! vstrlist_error --
+  !   Generates an error for the string list.
+  !
+  subroutine vstrlist_error ( this , message )
+    implicit none
+    type ( t_vstringlist ) , intent(in) :: this
+    character ( len = * ), intent (in) :: message
+    integer :: length
+    logical :: exists
+    write ( * , * ) "Internal error in m_vstringlist"
+    length =  vstrlist_length ( this )
+    exists = vstrlist_exists ( this )
+    if ( exists ) then
+       write ( * , * ) "Length:" , length
+    endif
+#ifdef _VSTRINGLIST_ALLOCATABLE
+    write ( * , * ) "Version : allocatable"
+#endif
+#ifdef _VSTRINGLIST_POINTERS
+    write ( * , * ) "Version : pointer"
+#endif
+    write ( * , * ) "Message :", trim( message )
+    if ( vstringlist_stoponerror ) then
+       STOP
+    endif
+  end subroutine vstrlist_error
+  ! 
+  ! vstringlist_set_stoponerror --
+  !   Configure the behaviour of the componenent whenever an 
+  !   error is met.
+  !   If stoponerror is true, then the execution stops if an error is encountered.
+  !   If stoponerror is false, then the execution continues if an error is encountered.
+  !   In both cases, a message is displayed on standard output.
+  ! 
+  subroutine vstringlist_set_stoponerror ( stoponerror )
+    logical , intent(in) :: stoponerror
+    vstringlist_stoponerror = stoponerror
+    call vstring_set_stoponerror ( stoponerror )
+  end subroutine vstringlist_set_stoponerror
+  !
+  ! vstrlist_remove --
+  !   Returns a new vstrlist by removing the vstring at the given index 
+  !   "icomponent" in the list.
+  !   Generates an error if the given index "icomponent" does not exist, that is,
+  !   is lower than 1 or greater than the number of strings in the list.
+  !
+  subroutine vstrlist_remove ( this , icomponent )
+    type ( t_vstringlist ) , intent(inout) :: this
+    integer , intent(in) :: icomponent
+    integer :: status
+    character ( len = 500 ) :: message
+    type ( t_vstringlist ) :: oldlist
+    call vstrlist_checkindex ( this , icomponent , status )
+    if ( status /= VSTRINGLIST_ERROR_OK ) then
+       write ( message , * ) "Wrong item index #", icomponent, " in current list"
+       call vstrlist_error ( this , message )
+       return
+    endif
+    !
+    ! Compute the new length and create the new list.
+    !
+    call vstrlist_new ( oldlist , vstrlist_length ( this ) - 1 )
+    if((icomponent > 1) .AND. (icomponent < vstrlist_length (this)))then
+        oldlist = vstrlist_concat( vstrlist_range ( this, 1, icomponent - 1 ), &
+                                 & vstrlist_range ( this, icomponent + 1,      &
+                                 &                  vstrlist_length ( this )))
+    elseif((icomponent == 1) .AND. (vstrlist_length (this) >= 2))then
+        oldlist = vstrlist_range ( this, 2, vstrlist_length ( this ))
+    elseif((icomponent == 1) .AND. (vstrlist_length (this) == 1))then
+        call vstrlist_free ( oldlist )
+        call vstrlist_new ( oldlist )
+    elseif(icomponent == vstrlist_length ( this ))then
+        oldlist = vstrlist_range ( this, 1, vstrlist_length ( this ) - 1)
+    endif
+    call vstrlist_free ( this )
+    this = oldlist
+    call vstrlist_free ( oldlist )
+  end subroutine vstrlist_remove
+end module m_vstringlist

--- a/src/flibs/src/strings/tokenize.F90
+++ b/src/flibs/src/strings/tokenize.F90
@@ -22,7 +22,7 @@
 ! TODO: delimiters!
 !
 !
-! $Id: tokenize.f90,v 1.4 2008/09/03 04:38:15 arjenmarkus Exp $
+! $Id$
 !
 
 ! TOKENIZE --
@@ -50,6 +50,7 @@ module TOKENIZE
 ! -------- Data structure defining the tokenizer
 !
     type tokenizer
+        integer               :: start_token
         integer               :: position
         character(len=10)     :: gaps
         character(len=10)     :: separators
@@ -138,9 +139,7 @@ function next_token( token, string, length )
     integer, intent(out)           :: length
 
     character(len=len(string))     :: next_token
-    !
-    ! Hasty implementation: only gaps
-    !
+
     if ( token%len_gaps .ne. 0 ) then
         next_token = next_token_gaps( token, string, length )
     else
@@ -181,13 +180,13 @@ function next_token_gaps( token, string, length )
 
 starttoken: &
     do while ( pos .le. lenstr )
-       if ( index(token%gaps(1:token%len_gaps), &
-                  string(pos:pos)) .gt. 0 ) then
-          pos = pos + 1
-       else
-          pos1 = pos
-          exit starttoken
-       endif
+        if ( index(token%gaps(1:token%len_gaps), &
+                   string(pos:pos)) .gt. 0 ) then
+           pos = pos + 1
+        else
+           pos1 = pos
+           exit starttoken
+        endif
     enddo starttoken
 
     if ( pos1 .gt. lenstr ) then
@@ -227,11 +226,12 @@ endtoken: &
     endif
 
     if ( pos1 .le. lenstr ) then
-       next_token_gaps = string(pos1:pos2)
-       length          = pos2-pos1+1
+       token%start_token = pos1
+       next_token_gaps   = string(pos1:pos2)
+       length            = pos2-pos1+1
     else
-       next_token_gaps = ' '
-       length          = -1
+       next_token_gaps   = ' '
+       length            = -1
     endif
 
     if ( .not. delim ) then
@@ -315,6 +315,7 @@ endtoken: &
     endif
 
     if ( pos1 .le. lenstr ) then
+        token%start_token = pos1
         next_token_separs = string(pos1:pos2)
         length            = pos2-pos1+1
     else

--- a/src/flibs/src/strings/tokenlist.F90
+++ b/src/flibs/src/strings/tokenlist.F90
@@ -1,0 +1,201 @@
+! tokenlist.f90 --
+!    Module for holding a list of tokens
+!
+! Note:
+! This module builds on the tokenize module. It simply provides
+! a more convenient interface.
+!
+! $Id$
+!
+
+! tokenlists --
+!    Module for holding tokenized strings
+!
+module tokenlists
+    use tokenize
+
+    implicit none
+
+    private
+    !
+    !  Define some convenient parameters:
+    !  whitespace - blanks only (gaps)
+    !  tsv        - tabs (typically as separators)
+    !  csv        - commas (typically as separators)
+    !  quotes     - " and ' (typically as delimiters)
+    !  empty      - no separators of this type
+    !
+    public :: token_whitespace
+    public :: token_tsv
+    public :: token_csv
+    public :: token_quotes
+    public :: token_empty
+
+    !
+    ! Data structure defining the tokenlist
+    !
+    type tokenlist
+        logical                                     :: initialized = .false.
+        type(tokenizer)                             :: tokenizer_data
+        character(len=1), dimension(:), allocatable :: char
+        integer, dimension(:), allocatable          :: first
+        integer, dimension(:), allocatable          :: length_token
+    contains
+        procedure                                   :: set_tokenizer => set_tokenizer_data
+        procedure                                   :: tokenize      => tokenize_string
+        procedure                                   :: number        => number_tokens
+        procedure                                   :: length        => length_of_token
+        procedure                                   :: token         => get_token
+    end type tokenlist
+
+    !
+    ! Other public items
+    !
+    public :: tokenlist
+
+contains
+
+! set_tokenizer_data
+!    Initialize the tokenlist with a proper tokenizer
+!
+! Arguments:
+!    list           The tokenlist
+!    gaps           Which characters form a gap
+!    separators     Which characters are separators
+!    delimiters     Which characters delimit tokens
+!
+subroutine set_tokenizer_data( list, gaps, separators, delimiters )
+    class(tokenlist), intent(inout) :: list
+    character(len=*), intent(in)   :: gaps
+    character(len=*), intent(in)   :: separators
+    character(len=*), intent(in)   :: delimiters
+
+    list%initialized = .true.
+    call set_tokenizer( list%tokenizer_data, gaps, separators, delimiters )
+
+end subroutine set_tokenizer_data
+
+! tokenize_string
+!    Construct a list of tokens from a string
+!
+! Arguments:
+!    list           The tokenlist
+!    string         String to tokenize
+!
+subroutine tokenize_string( list, string )
+    class(tokenlist), intent(inout)     :: list
+    character(len=*), intent(in)       :: string
+
+    integer                            :: i
+    integer                            :: idx
+    integer                            :: length_token
+    integer, dimension(:), allocatable :: first
+    integer, dimension(:), allocatable :: length
+    character(len=len(string))          :: token
+
+    !
+    ! First store the string and then determine the tokens
+    !
+    if ( allocated(list%char) ) then
+        deallocate( list%char         )
+        deallocate( list%first        )
+        deallocate( list%length_token )
+    endif
+    allocate( list%char(len(string)) )
+
+    do i = 1,len(string)
+        list%char(i) = string(i:i)
+    enddo
+
+    allocate( first(len(string)), length(len(string)) )
+
+    !
+    ! If we do not have a tokenizer yet, use a default
+    !
+    if ( .not. list%initialized ) then
+        list%initialized = .true.
+        call list%set_tokenizer( token_whitespace, token_empty, token_quotes )
+    endif
+
+    !
+    ! Now tokenize the string
+    !
+    idx   = 1
+    token = first_token( list%tokenizer_data, string, length_token )
+    do while ( length_token > -1 )
+        first(idx)  = list%tokenizer_data%start_token
+        length(idx) = length_token
+
+        token = next_token( list%tokenizer_data, string, length_token )
+        idx   = idx + 1
+    enddo
+
+    allocate( list%first(0:idx), list%length_token(0:idx) )
+
+    list%first(0)              = 0
+    list%first(idx)            = 0
+    list%length_token(0)       = 0
+    list%length_token(idx)     = 0
+    list%first(1:idx-1)        = first(1:idx-1)
+    list%length_token(1:idx-1) = length(1:idx-1)
+
+    deallocate( first, length )
+
+end subroutine tokenize_string
+
+! number_tokens
+!    Return the number of tokens
+!
+! Arguments:
+!    list           The tokenlist
+!
+integer function number_tokens( list )
+    class(tokenlist), intent(in) :: list
+
+    number_tokens = size(list%length_token) - 2
+
+end function number_tokens
+
+! length_token
+!    Return the length of a token
+!
+! Arguments:
+!    list           The tokenlist
+!    idx            Index of the token
+!
+integer function length_of_token( list, idx )
+    class(tokenlist), intent(in) :: list
+    integer, intent(in)         :: idx
+
+    if ( idx <= 0 .or. idx >= size(list%length_token)-1 ) then
+        length_of_token = 0
+    else
+        length_of_token = list%length_token(idx)
+    endif
+end function length_of_token
+
+! get_token
+!    Return the nth token (or zero-length string)
+!
+! Arguments:
+!    list           The tokenlist
+!    idx            Index of the token
+!
+function get_token( list, idx )
+    class(tokenlist), intent(in) :: list
+    integer, intent(in)         :: idx
+    character(len=(list%length_token(max(0,min(size(list%length_token)-2,idx))))) :: get_token
+
+    integer :: i, c
+
+    if ( idx <= 0 .or. idx >= size(list%length_token)-1 ) then
+        get_token = ''
+    else
+        do i = 1,list%length_token(idx)
+            c = list%first(idx) + i - 1
+            get_token(i:i) = list%char(c)
+        enddo
+    endif
+end function get_token
+
+end module tokenlists

--- a/src/tsp_output.F90
+++ b/src/tsp_output.F90
@@ -94,16 +94,14 @@ module TSP_OUTPUT
 
 ! -- Variables used for dealing with parameter groups.
      integer :: f_numpargp, igp, npargp
-     real, allocatable, dimension(:) :: derinc, derinclb, derincmul, f_derinc, &
-                                      & f_derinclb, f_derincmul
+     real, allocatable, dimension(:) :: f_derinc, f_derinclb, f_derincmul
      character(12) :: apargp
-     character(12), allocatable, dimension(:) :: dermthd, forcen, f_dermthd,   &
-                                               & f_forcen, f_inctyp,           &
-                                               & f_pargpnme, inctyp, pargpnme
+     character(12), allocatable, dimension(:) :: f_dermthd, f_forcen,          &
+                                               & f_inctyp, f_pargpnme
      character(120) :: pargroupfile
 
 ! -- Variables used for dealing with parameter data.
-     integer :: f_numpar, ipar, nnpar, npar, tempunit
+     integer :: f_numpar, ipar, npar, nnpar, tempunit
      real, allocatable, dimension(:) :: f_offset, f_parlbnd, f_parubnd,        &
                                       & f_parval1, f_scale
      character(1) :: pardelim
@@ -1979,17 +1977,13 @@ module TSP_OUTPUT
          write(lu_rec, *)
      endif
 
-     npar = vstrlist_length(groups_dat)
 !    -- Parameter and parameter group data are now assimilated on the basis of
 !    information read from the parameter data file, the parameter group file
 !    and the template files.
-     allocate(pargpnme(npar), inctyp(npar), derinc(npar), derinclb(npar),      &
-            & forcen(npar), derincmul(npar), dermthd(npar), STAT = ierr)
-     if(ierr/=0)goto 1700
  
 !    -- Parameter groups are now organised.
      npargp = 0
-     do ipar = 1, npar
+     do ipar = 1, f_numpar
          apargp = f_pargp(ipar)
          if(apargp=='none')then
              if((f_partrans(ipar)=='tied') .OR. (f_partrans(ipar)=='fixed'))cycle
@@ -2776,8 +2770,6 @@ module TSP_OUTPUT
                & f_derincmul, f_dermthd, STAT = ierr)
      deallocate(f_parnme, f_partrans, f_parchglim, f_parval1, f_parlbnd,       &
               & f_parubnd, f_pargp, f_scale, f_offset, STAT = ierr)
-     deallocate(pargpnme, inctyp, derinc, derinclb, forcen, derincmul, dermthd,&
-              & STAT = ierr)
 9122  format(/, ' Processing ', a, ' block....')
 9123  format(t5, a, ' ', a)
 9124  format('current version of TSPROC does not allow C_TABLES to be ',       &

--- a/src/tsp_output.F90
+++ b/src/tsp_output.F90
@@ -16,6 +16,26 @@ module TSP_OUTPUT
  
      contains
 
+
+     subroutine write_vstrlist(eq_sorted, wordcnt, lu_rec)
+     type (t_vstringlist), intent(in) :: eq_sorted
+     integer, intent(in) :: wordcnt, lu_rec
+
+     integer :: ipar
+     character(12) :: aapar
+
+     do ipar = 1, vstrlist_length(eq_sorted)
+         call vstring_cast(vstrlist_index(eq_sorted, ipar), aapar)
+         write(*, "(A13)", advance="no")aapar
+         write(lu_rec, "(A13)", advance="no")aapar
+         if(mod(ipar, wordcnt)==0)then
+             write(*, *)
+             write(lu_rec, *)
+         endif
+     enddo
+     end subroutine write_vstrlist
+
+
      subroutine PEST_FILES(Ifail, Lastblock)
 !    -- Subroutine PEST_FILES generates a PEST input dataset.
 
@@ -1906,31 +1926,30 @@ module TSP_OUTPUT
          goto 2400
      endif
 
-! -- Give WARNING about parameters not in any template.
-     if(vstrlist_length(dat_sorted) > 0)then
+     ! -- If equations then give WARNING about parameters not in any template,
+     ! -- however give an error if f_nequation==0
+     if(f_nequation>0 .AND. vstrlist_length(dat_sorted) > 0)then
          write(*, 9981)
          write(*, 9982)
 9981     format(/, /, "The following parameters are not in any template.")
 9982     format(/, "This could be fine since they might be used in an",        &
               & /, "equation, however listed here in case there might",        &
-              & /, "be a mistake and they should in fact be listed in",        &
-              & /, "a template.", /)
+              & /, "be a mistake and they should in fact be in a template",    &
+              & /, "file.", /)
               
          write(lu_rec, 9981)
          write(lu_rec, 9982)
-         do ipar = 1, vstrlist_length(dat_sorted)
-             call vstring_cast(vstrlist_index(dat_sorted, ipar), aapar)
-             write(*, "(A13)", advance="no")aapar
-             write(lu_rec, "(A13)", advance="no")aapar
-             if(mod(ipar, 5)==0)then
-                 write(*, *)
-                 write(lu_rec, *)
-             endif
-         enddo
+         call write_vstrlist(dat_sorted, 5, lu_rec)
          write(*, *)
          write(*, *)
          write(lu_rec, *)
          write(lu_rec, *)
+     elseif(f_nequation==0 .AND. vstrlist_length(dat_sorted) > 0)then
+         write(*, 9992)
+9992     format(/, /, 'The following parameters are not in any template file.',&
+              & /)
+         call write_vstrlist(dat_sorted, 5, lu_rec)
+         goto 2400
      endif
 
 ! -- Give WARNING about secondary parameters not in any template.
@@ -1941,15 +1960,7 @@ module TSP_OUTPUT
               & "template.")
          write(lu_rec, 9983)
          write(lu_rec, 9982)
-         do ipar = 1, vstrlist_length(eq_sorted)
-             call vstring_cast(vstrlist_index(eq_sorted, ipar), aapar)
-             write(*, "(A13)", advance="no")aapar
-             write(lu_rec, "(A13)", advance="no")aapar
-             if(mod(ipar, 5)==0)then
-                 write(*, *)
-                 write(lu_rec, *)
-             endif
-         enddo
+         call write_vstrlist(eq_sorted, 5, lu_rec)
          write(*, *)
          write(*, *)
          write(lu_rec, *)

--- a/src/tsp_output.F90
+++ b/src/tsp_output.F90
@@ -1460,6 +1460,19 @@ module TSP_OUTPUT
          endif
      enddo
  
+!    -- If any parameters are tied to a parameter which does not exist, this
+!       is now rectified.  The transformation is set to 'none', but might 
+!       should be an error.
+     do ipar = 1, f_numpar
+         if(f_partrans(ipar)(1:4)=='tied')then
+             aapar = f_partrans(ipar)(6:)
+             do i = 1, f_numpar
+                 if(aapar==f_parnme(i))goto 1200
+             enddo
+             f_partrans(ipar) = 'none'
+         endif
+1200  enddo
+
      call NUM2CHAR(f_numpar, aline)
      write(*, 9133)TRIM(aline), TRIM(sstring_g)
      write(lu_rec, 9133)TRIM(aline), TRIM(sstring_g)
@@ -1973,18 +1986,6 @@ module TSP_OUTPUT
      allocate(pargpnme(npar), inctyp(npar), derinc(npar), derinclb(npar),      &
             & forcen(npar), derincmul(npar), dermthd(npar), STAT = ierr)
      if(ierr/=0)goto 1700
-
-!    -- If any parameters are tied to a parameter which does not exist, this
-!       is now rectified.
-     do ipar = 1, npar
-         if(f_partrans(ipar)(1:4)=='tied')then
-             aapar = f_partrans(ipar)(6:)
-             do i = 1, npar
-                 if(aapar==apar(i))goto 1200
-             enddo
-             f_partrans(ipar) = 'none'
-         endif
-1200  enddo
  
 !    -- Parameter groups are now organised.
      npargp = 0

--- a/src/tsp_output.F90
+++ b/src/tsp_output.F90
@@ -1106,10 +1106,8 @@ module TSP_OUTPUT
      endif
 
 !    -- The file is read a first time to find out the number of groups
-     jline = 0
      f_numpargp = 0
      do
-         jline = jline + 1
          read(iunit, '(a)', err = 2000, end = 300)cline
          if(LEN_TRIM(cline)==0)cycle
          if(cline(1:1)=='#')cycle
@@ -1135,12 +1133,13 @@ module TSP_OUTPUT
      jline = 0
      igp = 0
      do
-         igp = igp + 1
          jline = jline + 1
          call NUM2CHAR(jline, aline)
          read(iunit, '(a)', err = 2000, end = 400)cline
          if(LEN_TRIM(cline)==0)cycle
          if(cline(1:1)=='#')cycle
+
+         igp = igp + 1
          call CASETRANS(cline, 'lo')
 
          call tlist%tokenize(cline)


### PR DESCRIPTION
This commit adds parameter equations supported by PEST_HP 14.22.  This means that a user can completely eliminate the use of par2par since parameter equations are implemented within PEST_HP itself.  The support for equations in tsproc required re-working WRITE_PEST_FILES block to correctly read the parameter data file, count the number of equations and secondary parameters, write out the additions to the control block, and equations out to the '* parameter data' block.  Should work on legacy parameter files without problem.

Steve, please review and if you have any concerns I would like to address within the branch before merging to master.

Kindest regards,
Tim